### PR TITLE
[Parse] Support dollar identifier; e.g. `$3`

### DIFF
--- a/Sources/ParseExpr.swift
+++ b/Sources/ParseExpr.swift
@@ -81,7 +81,7 @@ let exprIdentifier = _exprIdentifier()
 func _exprIdentifier() -> SwiftParser<IdentifierExpression> {
     return { ident in { generics in
         IdentifierExpression(identifier: ident) }}
-        <^> identifier
+        <^> (identifier <|> dollarIdentifier)
         <*> zeroOrOne(OWS *> genericArgs)
 }
 

--- a/Sources/ParsePrimitive.swift
+++ b/Sources/ParsePrimitive.swift
@@ -193,7 +193,11 @@ private func _keywordOrIdentifier() -> SwiftParser<String> {
     return identifierBody <|> escapedIdentifier
 }
 
-
+let dollarIdentifier = _dollarIdentifier()
+private func _dollarIdentifier() -> SwiftParser<String> {
+    return String.init
+        <^> (cons <^> char("$") <*> many1(satisfy(isDigit))) <* not(satisfy(isValidIdentifierContinuationCodePoint))
+}
 
 // ----------------------------------------------------------------------------------
 // Keywords

--- a/Tests/SwiftScriptTests/ParseExprTests.swift
+++ b/Tests/SwiftScriptTests/ParseExprTests.swift
@@ -13,9 +13,13 @@ class ParseExprTests: XCTestCase {
         XCTAssertTrue(parseSuccess(
             exprIdentifier, "foo"))
         XCTAssertTrue(parseSuccess(
+            exprIdentifier, "$12"))
+        XCTAssertTrue(parseSuccess(
             exprIdentifier, "foo<A, B>"))
         XCTAssertFalse(parseSuccess(
             exprIdentifier, "self"))
+        XCTAssertFalse(parseSuccess(
+            exprIdentifier, "`$1`"))
     }
     
     func testExprCall() {
@@ -116,6 +120,10 @@ class ParseExprTests: XCTestCase {
             exprClosure, "{ (x: Int, y: Int) -> Int in 1 }"))
         XCTAssertTrue(parseSuccess(
             exprClosure, "{ (x: Int, y: Int) throws -> Int in 1 }"))
+        XCTAssertTrue(parseSuccess(
+            exprClosure, "{ $0.foo[12] }"))
+        XCTAssertTrue(parseSuccess(
+            exprClosure, "{ let x = 1\n return $0 + 12\n}"))
     }
 
     func testExprAssign() {

--- a/Tests/SwiftScriptTests/ParsePrimitiveTests.swift
+++ b/Tests/SwiftScriptTests/ParsePrimitiveTests.swift
@@ -40,7 +40,18 @@ class ParsePrimitiveTests: XCTestCase {
         XCTAssertEqual(try parseIt(identifier, "foo"), "foo")
         XCTAssertEqual(try parseIt(identifier, "`is`"), "is")
         XCTAssertThrowsError(try parseIt(identifier, "is"))
+        XCTAssertThrowsError(try parseIt(identifier, "$f12"))
+        XCTAssertThrowsError(try parseIt(identifier, "$12"))
+    }
+    func testKeywordOrIdentifier() {
         XCTAssertEqual(try parseIt(keywordOrIdentifier, "is"), "is")
+        XCTAssertEqual(try parseIt(keywordOrIdentifier, "`is`"), "is")
+        XCTAssertThrowsError(try parseIt(keywordOrIdentifier, "$0"))
+        XCTAssertThrowsError(try parseIt(keywordOrIdentifier, "`$0`"))
+    }
+    func testDollerIdentifier() {
+        XCTAssertEqual(try parseIt(dollarIdentifier, "$12"), "$12")
+        XCTAssertThrowsError(try parseIt(dollarIdentifier, "`$0`"))
     }
     func testOWS() {
         XCTAssertTrue(parseSuccess(OWS, ""))


### PR DESCRIPTION
This is necessary for closure.