### PR TITLE
[Parse] Expand generics support

### DIFF
--- a/Sources/Declarations.swift
+++ b/Sources/Declarations.swift
@@ -28,11 +28,17 @@ public struct TypeAliasDeclaration: Declaration {
     public var type: Type_
 }
 
+public struct Parameter {
+    public var externalParameterName: String?
+    public var localParameterName: String
+    public var type: Type_
+    public var defaultArgument: Expression?
+}
 
 public struct FunctionDeclaration: Declaration {
     public var isStatic: Bool
     public var name: String
-    public var arguments: [(/*external-parameter-name*/ String?, String, Type_, Expression?)]
+    public var arguments: [Parameter]
     public var result: Type_?
     public var hasThrows: Bool
     public var body: [Statement]?
@@ -63,7 +69,7 @@ public struct ProtocolDeclaration­: Declaration {
 
 
 public struct InitializerDeclaration­: Declaration {
-    public var arguments: [(/*external-parameter-name*/ String?, String, Type_, Expression?)]
+    public var arguments: [Parameter]
     public var isFailable: Bool
     public var hasThrows: Bool
     public var body: [Statement]?

--- a/Sources/ParseDecl.swift
+++ b/Sources/ParseDecl.swift
@@ -46,10 +46,10 @@ func _declTypeAlias() -> SwiftParser<TypeAliasDeclaration> {
 }
 
 let declParam = _declParam()
-func _declParam() -> SwiftParser<(String?, String, Type_, Expression?)> {
+func _declParam() -> SwiftParser<Parameter> {
     let label = (identifier <|> kw__)
-    return { apiName in { paramName in { type in { isVariadic in { initializer in
-        (apiName, paramName, type, initializer) }}}}}
+    return { apiName in { paramName in { ty in { isVariadic in { defaultValue in
+        Parameter(externalParameterName: apiName, localParameterName: paramName, type: ty, defaultArgument: defaultValue) }}}}}
         <^> zeroOrOne(label <* WS)
         <*> (label <* OWS <* colon)
         <*> (OWS *> type)

--- a/Sources/ParseExpr.swift
+++ b/Sources/ParseExpr.swift
@@ -200,8 +200,10 @@ func _exprInitializer(_ subj: Expression) -> SwiftParser<InitializerExpression> 
 
 
 func _exprExplicitMember(_ subj: Expression) -> SwiftParser<ExplicitMemberExpression> {
-    return { name in ExplicitMemberExpression(expression: subj, member: name) }
-        <^> OWS *> period *> keywordOrIdentifier
+    return { name in { generics in
+        ExplicitMemberExpression(expression: subj, member: name) }}
+        <^> (OWS *> period *> keywordOrIdentifier)
+        <*> zeroOrOne(OWS *> genericArgs)
 }
 
 
@@ -212,8 +214,10 @@ func _exprSubscript(_ subj: Expression) -> SwiftParser<SubscriptExpression> {
 }
 
 func _exprOptionalChaining(_ subj: Expression) -> SwiftParser<OptionalChainingExpression> {
-    return { name in OptionalChainingExpression(expression: subj, member: name) }
+    return { name in { generics in
+        OptionalChainingExpression(expression: subj, member: name) }}
         <^> char("?") *> OWS *> period *> keywordOrIdentifier
+        <*> zeroOrOne(OWS *> genericArgs)
 }
 
 func _exprDynamicType(_ subj: Expression) -> SwiftParser<DynamicTypeExpression> {

--- a/Sources/TranslateDeclarations.swift
+++ b/Sources/TranslateDeclarations.swift
@@ -30,11 +30,11 @@ extension VariableDeclaration {
 
 extension FunctionDeclaration {
     public func javaScript(with indentLevel: Int) -> String {
-        let jsArguments: [String] = arguments.map { _, name, _, initialValue in
-            if let initialValue = initialValue {
-                return "\(name) = \(initialValue)"
+        let jsArguments: [String] = arguments.map { param in
+            if let initialValue = param.defaultArgument {
+                return "\(param.localParameterName) = \(initialValue)"
             } else {
-                return name
+                return param.localParameterName
             }
         }
         
@@ -104,11 +104,11 @@ extension ClassDeclaration­ {
 
 extension InitializerDeclaration­ {
     public func javaScript(with indentLevel: Int) -> String {
-        let jsArguments: [String] = arguments.map { _, name, _, initialValue in
-            if let initialValue = initialValue {
-                return "\(name) = \(initialValue)"
+        let jsArguments: [String] = arguments.map { param in
+            if let initialValue = param.defaultArgument {
+                return "\(param.localParameterName) = \(initialValue)"
             } else {
-                return name
+                return param.localParameterName
             }
         }
         // `body!` because `FunctionDeclaration` without `body` is for `protocol`s and thier `javaScript` is never called

--- a/Tests/SwiftScriptTests/DeclarationsTests.swift
+++ b/Tests/SwiftScriptTests/DeclarationsTests.swift
@@ -45,8 +45,18 @@ class DeclarationsTests: XCTestCase {
             isStatic: false,
             name: "foo",
             arguments: [
-                (nil, "bar", TypeIdentifier­(names: ["Int"]), nil),
-                (nil, "baz", TypeIdentifier­(names: ["String"]), nil),
+                Parameter(
+                    externalParameterName: nil,
+                    localParameterName: "bar",
+                    type: TypeIdentifier­(names: ["Int"]),
+                    defaultArgument: nil
+                ),
+                Parameter(
+                    externalParameterName: nil,
+                    localParameterName: "baz",
+                    type: TypeIdentifier­(names: ["String"]),
+                    defaultArgument: nil
+                ),
             ],
             result: nil,
             hasThrows: false,
@@ -58,9 +68,19 @@ class DeclarationsTests: XCTestCase {
             isStatic: false,
             name: "foo",
             arguments: [
-                ("bar", "x", TypeIdentifier­(names: ["Int"]), nil),
-                ("baz", "y", TypeIdentifier­(names: ["String"]), nil),
-                ],
+                Parameter(
+                    externalParameterName: "bar",
+                    localParameterName: "x",
+                    type: TypeIdentifier­(names: ["Int"]),
+                    defaultArgument: nil
+                ),
+                Parameter(
+                    externalParameterName: "baz",
+                    localParameterName: "y",
+                    type: TypeIdentifier­(names: ["String"]),
+                    defaultArgument: nil
+                ),
+            ],
             result: TypeIdentifier­(names: ["Void"]),
             hasThrows: true,
             body: []
@@ -71,9 +91,19 @@ class DeclarationsTests: XCTestCase {
             isStatic: false,
             name: "foo",
             arguments: [
-                (nil, "x", TypeIdentifier­(names: ["Int"]), nil),
-                (nil, "y", TypeIdentifier­(names: ["Int"]), nil),
-                ],
+                Parameter(
+                    externalParameterName: nil,
+                    localParameterName: "x",
+                    type: TypeIdentifier­(names: ["Int"]),
+                    defaultArgument: nil
+                ),
+                Parameter(
+                    externalParameterName: nil,
+                    localParameterName: "y",
+                    type: TypeIdentifier­(names: ["Int"]),
+                    defaultArgument: nil
+                ),
+            ],
             result: nil,
             hasThrows: false,
             body: [
@@ -90,9 +120,19 @@ class DeclarationsTests: XCTestCase {
             isStatic: false,
             name: "foo",
             arguments: [
-                (nil, "x", TypeIdentifier­(names: ["Int"]), nil),
-                (nil, "y", TypeIdentifier­(names: ["Int"]), nil),
-                ],
+                Parameter(
+                    externalParameterName: nil,
+                    localParameterName: "x",
+                    type: TypeIdentifier­(names: ["Int"]),
+                    defaultArgument: nil
+                ),
+                Parameter(
+                    externalParameterName: nil,
+                    localParameterName: "y",
+                    type: TypeIdentifier­(names: ["Int"]),
+                    defaultArgument: nil
+                ),
+            ],
             result: nil,
             hasThrows: false,
             body: [
@@ -130,7 +170,14 @@ class DeclarationsTests: XCTestCase {
                     expression: StringLiteral(value: "xyz")
                 ),
                 InitializerDeclaration­(
-                    arguments: [(nil, "bar", TypeIdentifier­(names: ["Int"]), nil)],
+                    arguments: [
+                        Parameter(
+                            externalParameterName: nil,
+                            localParameterName: "bar",
+                            type: TypeIdentifier­(names: ["Int"]),
+                            defaultArgument: nil
+                        ),
+                    ],
                     isFailable: false,
                     hasThrows: false,
                     body: [
@@ -181,7 +228,14 @@ class DeclarationsTests: XCTestCase {
                     expression: StringLiteral(value: "xyz")
                 ),
                 InitializerDeclaration­(
-                    arguments: [(nil, "bar", TypeIdentifier­(names: ["Int"]), nil)],
+                    arguments: [
+                        Parameter(
+                            externalParameterName: nil,
+                            localParameterName: "bar",
+                            type: TypeIdentifier­(names: ["Int"]),
+                            defaultArgument: nil
+                        ),
+                    ],
                     isFailable: false,
                     hasThrows: false,
                     body: [
@@ -216,8 +270,18 @@ class DeclarationsTests: XCTestCase {
         // arguments
         XCTAssertEqual(InitializerDeclaration­(
             arguments: [
-                (nil, "bar", TypeIdentifier­(names: ["Int"]), nil),
-                (nil, "baz", TypeIdentifier­(names: ["String"]), nil),
+                Parameter(
+                    externalParameterName: nil,
+                    localParameterName: "bar",
+                    type: TypeIdentifier­(names: ["Int"]),
+                    defaultArgument: nil
+                ),
+                Parameter(
+                    externalParameterName: nil,
+                    localParameterName: "baz",
+                    type: TypeIdentifier­(names: ["String"]),
+                    defaultArgument: nil
+                ),
             ],
             isFailable: false,
             hasThrows: false,

--- a/Tests/SwiftScriptTests/ParseDeclTests.swift
+++ b/Tests/SwiftScriptTests/ParseDeclTests.swift
@@ -14,6 +14,9 @@ class ParseDeclTests: XCTestCase {
         XCTAssertTrue(parseSuccess(
             declFunction,
             "static func foo() { }"))
+        XCTAssertTrue(parseSuccess(
+            declFunction,
+            "func foo<T>(x:T) throws -> C where T == X {}"))
     }
     
     func testDeclInitializer() {
@@ -25,6 +28,9 @@ class ParseDeclTests: XCTestCase {
         XCTAssertTrue(parseSuccess(
             declInitializer,
             "init?() {}"))
+        XCTAssertTrue(parseSuccess(
+            declInitializer,
+            "init?<T>(x: T) where T: Sequence {}"))
     }
     
     func testDeclClass() {
@@ -39,6 +45,10 @@ class ParseDeclTests: XCTestCase {
                 + "  init () {}\n"
                 + "  func foo() {}\n"
                 + "}"))
+        XCTAssertTrue(parseSuccess(
+            declClass, "class Foo: Base {}"))
+        XCTAssertTrue(parseSuccess(
+            declClass, "class Foo<X>: Base where X: Foo {}"))
     }
     
     func testDeclConstant() {

--- a/Tests/SwiftScriptTests/ParseExprTests.swift
+++ b/Tests/SwiftScriptTests/ParseExprTests.swift
@@ -22,6 +22,13 @@ class ParseExprTests: XCTestCase {
             exprIdentifier, "`$1`"))
     }
     
+    func testExprExplicitMember() {
+        XCTAssertTrue(parseSuccess(
+            expr, "foo.bar"))
+        XCTAssertTrue(parseSuccess(
+            expr, "foo.bar<A>"))
+    }
+    
     func testExprCall() {
         XCTAssertTrue(parseSuccess(
             expr, "foo(x)"))


### PR DESCRIPTION
For now, just skip them.
* call site; e.g. `Foo<Int>()`
* decl; e.g. `class Foo<X: A> where X: B {}`