### PR TITLE
fix optional chaining

### DIFF
--- a/Sources/Expressions.swift
+++ b/Sources/Expressions.swift
@@ -64,9 +64,3 @@ public struct SubscriptExpression: Expression {
     public var expression: Expression
     public var arguments: [Expression]
 }
-
-public struct OptionalChainingExpression: Expression {
-    public var expression: Expression
-    public var member: String
-}
-

--- a/Sources/ParseExpr.swift
+++ b/Sources/ParseExpr.swift
@@ -219,5 +219,5 @@ func _exprDynamicType(_ subj: Expression) -> SwiftParser<DynamicTypeExpression> 
 func _exprPostfixUnary(_ subj: Expression) -> SwiftParser<PostfixUnaryOperation> {
     return
         { _ in PostfixUnaryOperation(operand: subj, operatorSymbol: "!") }
-        <^> char("!")
+        <^> (char("!") <|> char("?"))
 }

--- a/Sources/ParseExpr.swift
+++ b/Sources/ParseExpr.swift
@@ -164,7 +164,6 @@ func exprSuffix(subj: Expression, isBasic: Bool) -> SwiftParser<Expression> {
         <|> (_exprExplicitMember(subj) >>- exprSuffix(isBasic: isBasic))
         <|> (_exprFunctionCall(subj) >>- exprSuffix(isBasic: isBasic))
         <|> (_exprSubscript(subj) >>- exprSuffix(isBasic: isBasic))
-        <|> (_exprOptionalChaining(subj) >>- exprSuffix(isBasic: isBasic))
         <|> (_exprPostfixUnary(subj) >>- exprSuffix(isBasic: isBasic))
     if !isBasic {
         parser = parser
@@ -211,13 +210,6 @@ func _exprSubscript(_ subj: Expression) -> SwiftParser<SubscriptExpression> {
     return { args in
         SubscriptExpression(expression: subj, arguments: args) }
         <^> (OHWS *> list(l_square, expr, comma, r_square))
-}
-
-func _exprOptionalChaining(_ subj: Expression) -> SwiftParser<OptionalChainingExpression> {
-    return { name in { generics in
-        OptionalChainingExpression(expression: subj, member: name) }}
-        <^> char("?") *> OWS *> period *> keywordOrIdentifier
-        <*> zeroOrOne(OWS *> genericArgs)
 }
 
 func _exprDynamicType(_ subj: Expression) -> SwiftParser<DynamicTypeExpression> {

--- a/Sources/TranslateExpressions.swift
+++ b/Sources/TranslateExpressions.swift
@@ -15,6 +15,11 @@ extension IdentifierExpression {
 
 extension FunctionCallExpression {
     public func javaScript(with indentLevel: Int) -> String {
+        if let expression = expression as? PostfixUnaryOperation, expression.operatorSymbol == "?" {
+            var zelf = self
+            zelf.expression = IdentifierExpression(identifier: "x")
+            return optionalChaining(expression.operand, zelf, indentLevel: indentLevel)
+        }
         var jsArguments: [String] = arguments.map { $1.javaScript(with: indentLevel) }
         if let closure = trailingClosure {
             jsArguments.append(closure.javaScript(with: indentLevel))
@@ -85,6 +90,11 @@ extension WildcardExpression {
 
 extension ExplicitMemberExpression {
     public func javaScript(with indentLevel: Int) -> String {
+        if let expression = expression as? PostfixUnaryOperation, expression.operatorSymbol == "?" {
+            var zelf = self
+            zelf.expression = IdentifierExpression(identifier: "x")
+            return optionalChaining(expression.operand, zelf, indentLevel: indentLevel)
+        }
         if expression is SuperclassExpression, member == "init" {
             return "\(expression.javaScript(with: indentLevel))"
         }
@@ -94,6 +104,11 @@ extension ExplicitMemberExpression {
 
 extension SubscriptExpression {
     public func javaScript(with indentLevel: Int) -> String {
+        if let expression = expression as? PostfixUnaryOperation, expression.operatorSymbol == "?" {
+            var zelf = self
+            zelf.expression = IdentifierExpression(identifier: "x")
+            return optionalChaining(expression.operand, zelf, indentLevel: indentLevel)
+        }
         var jsExpression = expression.javaScript(with: indentLevel)
         if expression is ClosureExpression {
             jsExpression = "(\(jsExpression))"
@@ -102,9 +117,6 @@ extension SubscriptExpression {
     }
 }
 
-extension OptionalChainingExpression {
-    public func javaScript(with indentLevel: Int) -> String {
-        let exp = expression.javaScript(with: indentLevel + 1)
-        return "q(\(exp), (x) => x.\(member)"
-    }
+private func optionalChaining(_ primary: Expression, _ secondary: Expression, indentLevel: Int) -> String {
+    return "q(\(primary.javaScript(with: indentLevel)), (x) => \(secondary.javaScript(with: indentLevel)))"
 }

--- a/Sources/TranslateOperations.swift
+++ b/Sources/TranslateOperations.swift
@@ -46,7 +46,7 @@ extension PostfixUnaryOperation {
         let value = operand.javaScript(with: indentLevel + 1)
         switch operatorSymbol {
         case "?":
-            return "q(\(value))"
+            fatalError("Never reaches here if semantic analysis is implemented.")
         case "!":
             return "x(\(value))"
         default:

--- a/Tests/SwiftScriptTests/ExpressionsTest.swift
+++ b/Tests/SwiftScriptTests/ExpressionsTest.swift
@@ -191,9 +191,29 @@ class ExpressionsTests: XCTestCase {
     }
     
     func testOptionalChainingExpression() {
-        XCTAssertEqual(OptionalChainingExpression(
-            expression: IdentifierExpression(identifier: "foo"),
+        XCTAssertEqual(ExplicitMemberExpression(
+            expression: PostfixUnaryOperation(
+                operand: IdentifierExpression(identifier: "foo"),
+                operatorSymbol: "?"
+            ),
             member: "bar"
-        ).javaScript(with: 0), "q(foo, (x) => x.bar")
+        ).javaScript(with: 0), "q(foo, (x) => x.bar)")
+        
+        XCTAssertEqual(SubscriptExpression(
+            expression: PostfixUnaryOperation(
+                operand: IdentifierExpression(identifier: "foo"),
+                operatorSymbol: "?"
+            ),
+            arguments: [IntegerLiteral(value: 0)]
+        ).javaScript(with: 0), "q(foo, (x) => x[0])")
+        
+        XCTAssertEqual(FunctionCallExpression(
+            expression: PostfixUnaryOperation(
+                operand: IdentifierExpression(identifier: "foo"),
+                operatorSymbol: "?"
+            ),
+            arguments: [],
+            trailingClosure: nil
+        ).javaScript(with: 0), "q(foo, (x) => x())")
     }
 }

--- a/Tests/SwiftScriptTests/ParseExprTests.swift
+++ b/Tests/SwiftScriptTests/ParseExprTests.swift
@@ -54,13 +54,6 @@ class ParseExprTests: XCTestCase {
             expr, "foo.bar[1, 2]"))
     }
 
-    func testExprOptionalChaining() {
-        XCTAssertTrue(parseSuccess(
-            expr, "foo?.bar"))
-        XCTAssertTrue(parseSuccess(
-            expr, "foo? .bar"))
-    }
-    
     func testExprPostixUnary() {
         XCTAssertTrue(parseSuccess(
             expr, "foo!"))

--- a/Tests/SwiftScriptTests/ParseExprTests.swift
+++ b/Tests/SwiftScriptTests/ParseExprTests.swift
@@ -56,17 +56,17 @@ class ParseExprTests: XCTestCase {
 
     func testExprPostixUnary() {
         XCTAssertTrue(parseSuccess(
-            expr, "foo!"))
+            exprAtom(isBasic: false), "foo!"))
         XCTAssertTrue(parseSuccess(
-            expr, "foo!.bar"))
+            exprAtom(isBasic: false), "foo!.bar"))
         XCTAssertTrue(parseSuccess(
-            expr, "foo?.bar"))
+            exprAtom(isBasic: false), "foo?.bar"))
         XCTAssertTrue(parseSuccess(
-            expr, "foo?()"))
+            exprAtom(isBasic: false), "foo?()"))
         XCTAssertTrue(parseSuccess(
-            expr, "foo?(bar)"))
+            exprAtom(isBasic: false), "foo?(bar)"))
         XCTAssertTrue(parseSuccess(
-            expr, "foo?[bar]"))
+            exprAtom(isBasic: false), "foo?[bar]"))
     }
     
     func testExprParen() {

--- a/Tests/SwiftScriptTests/ParseExprTests.swift
+++ b/Tests/SwiftScriptTests/ParseExprTests.swift
@@ -59,6 +59,14 @@ class ParseExprTests: XCTestCase {
             expr, "foo!"))
         XCTAssertTrue(parseSuccess(
             expr, "foo!.bar"))
+        XCTAssertTrue(parseSuccess(
+            expr, "foo?.bar"))
+        XCTAssertTrue(parseSuccess(
+            expr, "foo?()"))
+        XCTAssertTrue(parseSuccess(
+            expr, "foo?(bar)"))
+        XCTAssertTrue(parseSuccess(
+            expr, "foo?[bar]"))
     }
     
     func testExprParen() {


### PR DESCRIPTION
- Supported function calls `foo?(bar)` and subscripts `foo?[bar]`.