### PR TITLE
Supporting library namespace

### DIFF
--- a/Sources/SupportingLibrary.swift
+++ b/Sources/SupportingLibrary.swift
@@ -77,7 +77,7 @@ struct SupportingLibrary {
     }
 
     static func javaScript(for supports: Set<Support>, namespace: String = "$ss") -> String {
-        let localVariableName = "globalObj"
+        let localVariableName = "ss"
         let functionDeclarations = supports.map { support -> String in
             let function = support.function
             let declaration = addIndent(to: function.declaration, indentLevel: 1)

--- a/Sources/SupportingLibrary.swift
+++ b/Sources/SupportingLibrary.swift
@@ -12,7 +12,7 @@ struct SupportingLibrary {
         case optionalChaining
         case range
         case closedRange
-        case `is`
+        case typeChecking
         case nilCoalescing
 
         var function: Function {
@@ -57,7 +57,7 @@ struct SupportingLibrary {
                     name: "closedRange",
                     declaration: "function closedRange(from, to) {\n  return (function* () {\n    var current = from;\n    while (current <= to) {\n      yield current++;\n    }\n  })();\n}"
                 )
-            case .`is`:
+            case .typeChecking:
                 return Function(
                     name: "is",
                     declaration: "function is(expression, type) {\n  if (type == String) {\n    return typeof (expression) == 'string' || expression instanceof String;\n  } else if (type == Number) {\n    return typeof (expression) == 'number' || expression instanceof Number;\n  }\n  return expression instanceof type;\n}"

--- a/Sources/SupportingLibrary.swift
+++ b/Sources/SupportingLibrary.swift
@@ -4,20 +4,20 @@ struct SupportingLibrary {
         let declaration: String
     }
     enum Support {
-        case forceCast
+        case forcedCast
         case optionalCast
-        case forceTry
+        case forcedTry
         case optionalTry
-        case forceUnwrap
-        case optionalChain
+        case forcedUnwrapping
+        case optionalChaining
         case range
         case closedRange
         case `is`
-        case nicCoalescing
+        case nilCoalescing
 
         var function: Function {
             switch self {
-            case .forceCast:
+            case .forcedCast:
                 return Function(
                     name: "asx",
                     declaration: "function asx(expression, type_test) {\n  if type_test() {\n    throw Error(\"Failed to cast\");\n  }\n  return expression;\n}"
@@ -27,7 +27,7 @@ struct SupportingLibrary {
                     name: "asq",
                     declaration: "function asq(expression, type_test) {\n  return type_test() ? expression : null;\n}"
                 )
-            case .forceTry:
+            case .forcedTry:
                 return Function(
                     name: "tryx",
                     declaration: "function tryx(command) {\n  try {\n    return command();\n  }\n  catch(e) {\n    // TODO: some force stopping method\n    throw e;\n  }\n}"
@@ -37,12 +37,12 @@ struct SupportingLibrary {
                     name: "tryq",
                     declaration: "function tryq(command) {\n  try {\n    return command();\n  }\n  catch(e) {\n    return null;\n  }\n}"
                 )
-            case .forceUnwrap:
+            case .forcedUnwrapping:
                 return Function(
                     name: "x",
                     declaration: "function x(expression) {\n  const is_null = (expression == null || typeof expression == 'undefined');\n  if (is_null) {\n    throw Error(\"Failed unwrapping\");\n  }\n  return expression;\n}"
                 )
-            case .optionalChain:
+            case .optionalChaining:
                 return Function(
                     name: "q",
                     declaration: "function q(expression, command) {\n  const is_null = (expression == null || typeof expression == 'undefined');\n  return is_null ? null : command();\n}"
@@ -62,7 +62,7 @@ struct SupportingLibrary {
                     name: "is",
                     declaration: "function is(expression, type) {\n  if (type == String) {\n    return typeof (expression) == 'string' || expression instanceof String;\n  } else if (type == Number) {\n    return typeof (expression) == 'number' || expression instanceof Number;\n  }\n  return expression instanceof type;\n}"
                 )
-            case .nicCoalescing:
+            case .nilCoalescing:
                 return Function(
                     name: "qq",
                     declaration: "function qq(expression, value) {\n  const is_null = (expression == null || typeof expression == 'undefined');\n  return is_null ? value : expression;\n}"

--- a/Sources/SupportingLibrary.swift
+++ b/Sources/SupportingLibrary.swift
@@ -1,12 +1,94 @@
 struct SupportingLibrary {
-    let forceCast = "function asx(expression, type_test) {\n  if type_test() {\n    throw Error(\"Failed to cast\");\n  }\n  return expression;\n}\n"
-    let forceTry = "function tryx(command) {\n  try {\n    return command();\n  }\n  catch(e) {\n    // TODO: some force stopping method\n    throw e;\n  }\n}\n"
-    let forceUnwrap = "function x(expression) {\n  const is_null = (expression == null || typeof expression == 'undefined');\n  if (is_null) {\n    throw Error(\"Failed unwrapping\");\n  }\n  return expression;\n}\n"
-    let `is` = "function is(expression, type) {\n  if (type == String) {\n    return typeof (expression) == 'string' || expression instanceof String;\n  } else if (type == Number) {\n    return typeof (expression) == 'number' || expression instanceof Number;\n  }\n  return expression instanceof type;\n}\n"
-    let nilCoalescing = "function qq(expression, value) {\n  const is_null = (expression == null || typeof expression == 'undefined');\n  return is_null ? value : expression;\n}\n"
-    let optionalCast = "function asq(expression, type_test) {\n  return type_test() ? expression : null;\n}\n"
-    let optionalChain = "function q(expression, command) {\n  const is_null = (expression == null || typeof expression == 'undefined');\n  return is_null ? null : command();\n}\nmodule.exports = {'q': q};\n"
-    let optionalTry = "function tryq(command) {\n  try {\n    return command();\n  }\n  catch(e) {\n    return null;\n  }\n}\n"
-    let range = "function range(from, to) {\n  return (function* () {\n    var current = from;\n    while (current < to) {\n      yield current++;\n    }\n  })();\n}\n"
-    let closedRange = "function closedRange(from, to) {\n  return (function* () {\n    var current = from;\n    while (current <= to) {\n      yield current++;\n    }\n  })();\n}\n"
+    struct Function {
+        let name: String
+        let declaration: String
+    }
+    enum Support {
+        case forceCast
+        case optionalCast
+        case forceTry
+        case optionalTry
+        case forceUnwrap
+        case optionalChain
+        case range
+        case closedRange
+        case `is`
+        case nicCoalescing
+
+        var function: Function {
+            switch self {
+            case .forceCast:
+                return Function(
+                    name: "asx",
+                    declaration: "function asx(expression, type_test) {\n  if type_test() {\n    throw Error(\"Failed to cast\");\n  }\n  return expression;\n}"
+                )
+            case .optionalCast:
+                return Function(
+                    name: "asq",
+                    declaration: "function asq(expression, type_test) {\n  return type_test() ? expression : null;\n}"
+                )
+            case .forceTry:
+                return Function(
+                    name: "tryx",
+                    declaration: "function tryx(command) {\n  try {\n    return command();\n  }\n  catch(e) {\n    // TODO: some force stopping method\n    throw e;\n  }\n}"
+                )
+            case .optionalTry:
+                return Function(
+                    name: "tryq",
+                    declaration: "function tryq(command) {\n  try {\n    return command();\n  }\n  catch(e) {\n    return null;\n  }\n}"
+                )
+            case .forceUnwrap:
+                return Function(
+                    name: "x",
+                    declaration: "function x(expression) {\n  const is_null = (expression == null || typeof expression == 'undefined');\n  if (is_null) {\n    throw Error(\"Failed unwrapping\");\n  }\n  return expression;\n}"
+                )
+            case .optionalChain:
+                return Function(
+                    name: "q",
+                    declaration: "function q(expression, command) {\n  const is_null = (expression == null || typeof expression == 'undefined');\n  return is_null ? null : command();\n}"
+                )
+            case .range:
+                return Function(
+                    name: "range",
+                    declaration: "function range(from, to) {\n  return (function* () {\n    var current = from;\n    while (current < to) {\n      yield current++;\n    }\n  })();\n}"
+                )
+            case .closedRange:
+                return Function(
+                    name: "closedRange",
+                    declaration: "function closedRange(from, to) {\n  return (function* () {\n    var current = from;\n    while (current <= to) {\n      yield current++;\n    }\n  })();\n}"
+                )
+            case .`is`:
+                return Function(
+                    name: "is",
+                    declaration: "function is(expression, type) {\n  if (type == String) {\n    return typeof (expression) == 'string' || expression instanceof String;\n  } else if (type == Number) {\n    return typeof (expression) == 'number' || expression instanceof Number;\n  }\n  return expression instanceof type;\n}"
+                )
+            case .nicCoalescing:
+                return Function(
+                    name: "qq",
+                    declaration: "function qq(expression, value) {\n  const is_null = (expression == null || typeof expression == 'undefined');\n  return is_null ? value : expression;\n}"
+                )
+            }
+        }
+    }
+
+    private static func addIndent(to text: String, indentLevel: Int) -> String {
+        let spaces = indent(of: indentLevel)
+        return (text.components(separatedBy: "\n").map { spaces + $0 }).joined(separator: "\n")
+    }
+
+    static func javaScript(for supports: Set<Support>, namespace: String = "$ss") -> String {
+        let localVariableName = "globalObj"
+        let functionDeclarations = supports.map { support -> String in
+            let function = support.function
+            let declaration = addIndent(to: function.declaration, indentLevel: 1)
+            return "\(declaration)\n\(indent(of: 1))\(localVariableName).\(function.name) = \(function.name);"
+        }.joined(separator: "\n")
+
+        return [
+            "\(namespace) = {};",
+            "((\(localVariableName)) => {",
+            functionDeclarations,
+            "})(\(namespace));"
+        ].joined(separator: "\n")
+    }
 }

--- a/Tests/SwiftScriptTests/SupportingLinbraryTests.swift
+++ b/Tests/SwiftScriptTests/SupportingLinbraryTests.swift
@@ -4,6 +4,6 @@ import XCTest
 class SupportingLibraryTests: XCTestCase {
     func testJavascript() {
         let script = SupportingLibrary.javaScript(for: Set([.optionalCast]))
-        XCTAssertEqual(script, "$ss = {};\n((globalObj) => {\n    function asq(expression, type_test) {\n      return type_test() ? expression : null;\n    }\n    globalObj.asq = asq;\n})($ss);")
+        XCTAssertEqual(script, "$ss = {};\n((ss) => {\n    function asq(expression, type_test) {\n      return type_test() ? expression : null;\n    }\n    ss.asq = asq;\n})($ss);")
     }
 }

--- a/Tests/SwiftScriptTests/SupportingLinbraryTests.swift
+++ b/Tests/SwiftScriptTests/SupportingLinbraryTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import SwiftScript
+
+class SupportingLibraryTests: XCTestCase {
+    func testJavascript() {
+        let script = SupportingLibrary.javaScript(for: Set([.optionalCast]))
+        XCTAssertEqual(script, "$ss = {};\n((globalObj) => {\n    function asq(expression, type_test) {\n      return type_test() ? expression : null;\n    }\n    globalObj.asq = asq;\n})($ss);")
+    }
+}


### PR DESCRIPTION
Introduce the function to embed supporting library using namespace.

### ex) 

- usage
```swift
let script = SupportingLibrary.javaScript(for: Set([.optionalCast, .forceCast]), namespace: "$ss")
print(script)
```

- result
```javascript
$ss = {};
((globalObj) => {
    function asx(expression, type_test) {
      if type_test() {
        throw Error("Failed to cast");
      }
      return expression;
    }
    globalObj.asx = asx;
    function asq(expression, type_test) {
      return type_test() ? expression : null;
    }
    globalObj.asq = asq;
})($ss);
```