### PR TITLE
[AST] Stop Expression and Declaration conform Statement protocol

### DIFF
--- a/Sources/Declarations.swift
+++ b/Sources/Declarations.swift
@@ -1,4 +1,4 @@
-public protocol Declaration: Statement {
+public protocol Declaration: Node {
     
 }
 

--- a/Sources/Expressions.swift
+++ b/Sources/Expressions.swift
@@ -1,4 +1,4 @@
-public protocol Expression: Statement {
+public protocol Expression: Node {
     
 }
 

--- a/Sources/ParseStmt.swift
+++ b/Sources/ParseStmt.swift
@@ -13,9 +13,9 @@ func _stmtBraceItems() -> SwiftParser<[Statement]> {
 
 let stmtBraceItem = _stmtBraceItem()
 func _stmtBraceItem() -> SwiftParser<Statement> {
-    return (decl <&> asStmt)
+    return (decl <&> { decl in DeclStatement(decl) })
         <|> (stmt <&> asStmt)
-        <|> (expr <&> asStmt)
+        <|> (expr <&> { expr in ExprStatement(expr) })
 }
 
 

--- a/Sources/Statements.swift
+++ b/Sources/Statements.swift
@@ -86,3 +86,20 @@ public struct DoStatement: Statement {
 public struct CatchClause: Node {
     // TODO
 }
+
+
+public struct ExprStatement: Statement {
+    public var expression: Expression
+    
+    public init(_ expression: Expression) {
+        self.expression = expression
+    }
+}
+
+public struct DeclStatement: Statement {
+    public var declaration: Declaration
+    
+    public init(_ expression: Declaration) {
+        self.declaration = expression
+    }
+}

--- a/Sources/TranslateDeclarations.swift
+++ b/Sources/TranslateDeclarations.swift
@@ -75,11 +75,11 @@ extension ClassDeclaration­ {
                     fatalError("Never reaches here.")
                 }
                 
-                initializer.body!.append(BinaryOperation(
+                initializer.body!.append(ExprStatement(BinaryOperation(
                     leftOperand: ExplicitMemberExpression(expression: SelfExpression(), member: name),
                     operatorSymbol: "=",
                     rightOperand: initialValue
-                ))
+                )))
             }
             
             return initializer

--- a/Sources/TranslateExpressions.swift
+++ b/Sources/TranslateExpressions.swift
@@ -58,8 +58,8 @@ extension ClosureExpression {
             return "(\(jsArguments)) => {}"
         case 1:
             let statement = statements[0]
-            if statement is Expression {
-                return "(\(jsArguments)) => \(statement.javaScript(with: indentLevel))"
+            if let exprStmt = statement as? ExprStatement {
+                return "(\(jsArguments)) => \(exprStmt.expression.javaScript(with: indentLevel))"
             } else {
                 return "(\(jsArguments)) => \(transpileBlock(statements: statements, indentLevel: indentLevel))"
             }

--- a/Sources/TranslateStatements.swift
+++ b/Sources/TranslateStatements.swift
@@ -49,7 +49,9 @@ extension IfStatement {
             }
             
             return DoStatement(statements: [
-                VariableDeclaration(isStatic: false, name: name, type: nil, expression: nil),
+                DeclStatement(
+                    VariableDeclaration(isStatic: false, name: name, type: nil, expression: nil)
+                ),
                 IfStatement(
                     condition: .boolean(BinaryOperation(
                         leftOperand: ParenthesizedExpression(expression: BinaryOperation(
@@ -91,7 +93,7 @@ extension GuardStatement {
             }
             
             return transpileStatements(statements: [
-                VariableDeclaration(isStatic: false, name: name, type: nil, expression: nil),
+                DeclStatement(VariableDeclaration(isStatic: false, name: name, type: nil, expression: nil)),
                 IfStatement(
                     condition: .boolean(BinaryOperation(
                         leftOperand: ParenthesizedExpression(expression: BinaryOperation(
@@ -166,5 +168,17 @@ extension DoStatement {
     public func javaScript(with indentLevel: Int) -> String {
         // TODO: catch
         return "\(indent(of: indentLevel))\(transpileBlock(statements: statements, indentLevel: indentLevel))\n"
+    }
+}
+
+extension ExprStatement {
+    public func javaScript(with indentLevel: Int) -> String {
+        return "\(indent(of: indentLevel))\(expression.javaScript(with: indentLevel));\n"
+    }
+}
+
+extension DeclStatement {
+    public func javaScript(with indentLevel: Int) -> String {
+        return declaration.javaScript(with: indentLevel)
     }
 }

--- a/Sources/Transpile.swift
+++ b/Sources/Transpile.swift
@@ -7,20 +7,13 @@ public func transpile(code: String) throws -> String {
 
 public func transpileStatements(statements: [Statement], indentLevel: Int) -> String {
     let jsStatements: [String] = statements.map { statement in
-        if let expression = statement as? Expression {
-            return transpileExpressionStatement(expression: expression, indentLevel: indentLevel)
-        }
-        return statement.javaScript(with: indentLevel)
+        statement.javaScript(with: indentLevel)
     }
     return jsStatements.joined()
 }
 
 public func transpileBlock(statements: [Statement], indentLevel: Int) -> String {
     return "{\n\(transpileStatements(statements: statements, indentLevel: indentLevel + 1))\(indent(of: indentLevel))}"
-}
-
-public func transpileExpressionStatement(expression: Expression, indentLevel: Int) -> String {
-    return "\(indent(of: indentLevel))\(expression.javaScript(with: indentLevel));\n"
 }
 
 public func indent(of level: Int) -> String {

--- a/Tests/SwiftScriptTests/DeclarationsTests.swift
+++ b/Tests/SwiftScriptTests/DeclarationsTests.swift
@@ -181,14 +181,14 @@ class DeclarationsTests: XCTestCase {
                     isFailable: false,
                     hasThrows: false,
                     body: [
-                        BinaryOperation(
+                        ExprStatement(BinaryOperation(
                             leftOperand: ExplicitMemberExpression(
                                 expression: SelfExpression(),
                                 member: "bar"
                             ),
                             operatorSymbol: "=",
                             rightOperand: IntegerLiteral(value: 42)
-                        )
+                        ))
                     ]
                 ),
             ]
@@ -239,14 +239,14 @@ class DeclarationsTests: XCTestCase {
                     isFailable: false,
                     hasThrows: false,
                     body: [
-                        BinaryOperation(
+                        ExprStatement(BinaryOperation(
                             leftOperand: ExplicitMemberExpression(
                                 expression: SelfExpression(),
                                 member: "bar"
                             ),
                             operatorSymbol: "=",
                             rightOperand: IntegerLiteral(value: 42)
-                        )
+                        ))
                     ]
                 ),
                 ]
@@ -259,11 +259,11 @@ class DeclarationsTests: XCTestCase {
             isFailable: false,
             hasThrows: false,
             body: [
-                BinaryOperation(
+                ExprStatement(BinaryOperation(
                     leftOperand: ExplicitMemberExpression(expression: SelfExpression(), member: "foo"),
                     operatorSymbol: "=",
                     rightOperand: IntegerLiteral(value: 42)
-                )
+                ))
             ]
         ).javaScript(with: 0), "constructor() {\n    this.foo = 42;\n}\n")
         
@@ -286,7 +286,7 @@ class DeclarationsTests: XCTestCase {
             isFailable: false,
             hasThrows: false,
             body: [
-                BinaryOperation(
+                ExprStatement(BinaryOperation(
                     leftOperand: ExplicitMemberExpression(expression: SelfExpression(), member: "foo"),
                     operatorSymbol: "=",
                     rightOperand: BinaryOperation(
@@ -294,7 +294,7 @@ class DeclarationsTests: XCTestCase {
                         operatorSymbol: "+",
                         rightOperand: IdentifierExpression(identifier: "baz")
                     )
-                )
+                ))
             ]
         ).javaScript(with: 0), "constructor(bar, baz) {\n    this.foo = bar + baz;\n}\n")
         
@@ -304,11 +304,11 @@ class DeclarationsTests: XCTestCase {
             isFailable: false,
             hasThrows: false,
             body: [
-                BinaryOperation(
+                ExprStatement(BinaryOperation(
                     leftOperand: ExplicitMemberExpression(expression: SelfExpression(), member: "foo"),
                     operatorSymbol: "=",
                     rightOperand: IntegerLiteral(value: 42)
-                )
+                ))
             ]
         ).javaScript(with: 1), "    constructor() {\n        this.foo = 42;\n    }\n")
     }

--- a/Tests/SwiftScriptTests/ExpressionsTest.swift
+++ b/Tests/SwiftScriptTests/ExpressionsTest.swift
@@ -27,7 +27,7 @@ class ExpressionsTests: XCTestCase {
             arguments: [],
             hasThrows: false,
             result: nil,
-            statements: [IntegerLiteral(value: 42)]
+            statements: [ExprStatement(IntegerLiteral(value: 42))]
         ).javaScript(with: 0), "() => 42")
         
         // multiple statments
@@ -36,7 +36,7 @@ class ExpressionsTests: XCTestCase {
             hasThrows: false,
             result: nil,
             statements: [
-                ConstantDeclaration(isStatic: false, name: "foo", type: TypeIdentifier­(names: ["Int"]), expression: IntegerLiteral(value: 42)),
+                DeclStatement(ConstantDeclaration(isStatic: false, name: "foo", type: TypeIdentifier­(names: ["Int"]), expression: IntegerLiteral(value: 42))),
                 ReturnStatement(expression: IdentifierExpression(identifier: "foo"))
             ]
         ).javaScript(with: 0), "() => {\n    const foo = 42;\n    return foo;\n}")
@@ -47,7 +47,7 @@ class ExpressionsTests: XCTestCase {
             hasThrows: false,
             result: nil,
             statements: [
-                ConstantDeclaration(isStatic: false, name: "foo", type: TypeIdentifier­(names: ["Int"]), expression: IntegerLiteral(value: 42)),
+                DeclStatement(ConstantDeclaration(isStatic: false, name: "foo", type: TypeIdentifier­(names: ["Int"]), expression: IntegerLiteral(value: 42))),
                 ReturnStatement(expression: IdentifierExpression(identifier: "foo"))
             ]
         ).javaScript(with: 1), "() => {\n        const foo = 42;\n        return foo;\n    }")
@@ -57,7 +57,7 @@ class ExpressionsTests: XCTestCase {
             arguments: [],
             hasThrows: true,
             result: nil,
-            statements: [IntegerLiteral(value: 42)]
+            statements: [ExprStatement(IntegerLiteral(value: 42))]
         ).javaScript(with: 0), "() => 42")
         
         // arguments
@@ -65,11 +65,11 @@ class ExpressionsTests: XCTestCase {
             arguments: [("x", nil), ("y", nil)],
             hasThrows: false,
             result: nil,
-            statements: [BinaryOperation(
+            statements: [ExprStatement(BinaryOperation(
                 leftOperand: IdentifierExpression(identifier: "x"),
                 operatorSymbol: "+",
                 rightOperand: IdentifierExpression(identifier: "y")
-            )]
+            ))]
         ).javaScript(with: 0), "(x, y) => x + y")
         
         // arguments with types
@@ -77,11 +77,11 @@ class ExpressionsTests: XCTestCase {
             arguments: [("x", TypeIdentifier­(names: ["Int"])), ("y", TypeIdentifier­(names: ["Int"]))],
             hasThrows: false,
             result: TypeIdentifier­(names: ["Int"]),
-            statements: [BinaryOperation(
+            statements: [ExprStatement(BinaryOperation(
                 leftOperand: IdentifierExpression(identifier: "x"),
                 operatorSymbol: "+",
                 rightOperand: IdentifierExpression(identifier: "y")
-                )]
+                ))]
             ).javaScript(with: 0), "(x, y) => x + y")
     }
     
@@ -155,7 +155,7 @@ class ExpressionsTests: XCTestCase {
         // calls just after a closure expression
         XCTAssertEqual(FunctionCallExpression(
             expression: ClosureExpression(arguments: [], hasThrows: false, result: nil, statements: [
-                IntegerLiteral(value: 42),
+                ExprStatement(IntegerLiteral(value: 42)),
             ]),
             arguments: [],
             trailingClosure: nil
@@ -184,7 +184,7 @@ class ExpressionsTests: XCTestCase {
         // calls just after a closure expression
         XCTAssertEqual(SubscriptExpression(
             expression: ClosureExpression(arguments: [], hasThrows: false, result: nil, statements: [
-                IntegerLiteral(value: 42),
+                ExprStatement(IntegerLiteral(value: 42)),
                 ]),
             arguments: [IntegerLiteral(value: 0)]
         ).javaScript(with: 0), "(() => 42)[0]")

--- a/Tests/SwiftScriptTests/StatementsTests.swift
+++ b/Tests/SwiftScriptTests/StatementsTests.swift
@@ -11,11 +11,11 @@ class StatementsTests: XCTestCase {
                 rightOperand: IntegerLiteral(value: 10)
             ),
             statements: [
-                FunctionCallExpression(
+                ExprStatement(FunctionCallExpression(
                     expression: IdentifierExpression(identifier: "print"),
                     arguments: [(nil, IdentifierExpression(identifier: "i"))],
                     trailingClosure: nil
-                )
+                ))
             ]
         ).javaScript(with: 0), "for (i of range(0, 10) {\n    console.log(i);\n}\n")
         
@@ -28,11 +28,11 @@ class StatementsTests: XCTestCase {
                 rightOperand: IntegerLiteral(value: 10)
             ),
             statements: [
-                FunctionCallExpression(
+                ExprStatement(FunctionCallExpression(
                     expression: IdentifierExpression(identifier: "print"),
                     arguments: [(nil, IdentifierExpression(identifier: "i"))],
                     trailingClosure: nil
-                )
+                ))
             ]
         ).javaScript(with: 1), "    for (i of range(0, 10) {\n        console.log(i);\n    }\n")
     }
@@ -41,11 +41,11 @@ class StatementsTests: XCTestCase {
         XCTAssertEqual(WhileStatement(
             condition: BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "<", rightOperand: IntegerLiteral(value: 42)),
             statements: [
-                FunctionCallExpression(
+                ExprStatement(FunctionCallExpression(
                     expression: IdentifierExpression(identifier: "print"),
                     arguments: [(nil, StringLiteral(value: "Hello"))],
                     trailingClosure: nil
-                )
+                ))
             ]
         ).javaScript(with: 0), "while (foo < 42) {\n    console.log(\"Hello\");\n}\n")
         
@@ -53,11 +53,11 @@ class StatementsTests: XCTestCase {
         XCTAssertEqual(WhileStatement(
             condition: BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "<", rightOperand: IntegerLiteral(value: 42)),
             statements: [
-                FunctionCallExpression(
+                ExprStatement(FunctionCallExpression(
                     expression: IdentifierExpression(identifier: "print"),
                     arguments: [(nil, StringLiteral(value: "Hello"))],
                     trailingClosure: nil
-                )
+                ))
             ]
         ).javaScript(with: 1), "    while (foo < 42) {\n        console.log(\"Hello\");\n    }\n")
     }
@@ -65,11 +65,11 @@ class StatementsTests: XCTestCase {
     func testRepeatWhileStatement() {
         XCTAssertEqual(RepeatWhileStatement(
             statements: [
-                FunctionCallExpression(
+                ExprStatement(FunctionCallExpression(
                     expression: IdentifierExpression(identifier: "print"),
                     arguments: [(nil, StringLiteral(value: "Hello"))],
                     trailingClosure: nil
-                )
+                ))
             ],
             condition: BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "<", rightOperand: IntegerLiteral(value: 42))
         ).javaScript(with: 0), "repeat {\n    console.log(\"Hello\");\n} while (foo < 42)\n")
@@ -77,11 +77,11 @@ class StatementsTests: XCTestCase {
         // indent
         XCTAssertEqual(RepeatWhileStatement(
             statements: [
-                FunctionCallExpression(
+                ExprStatement(FunctionCallExpression(
                     expression: IdentifierExpression(identifier: "print"),
                     arguments: [(nil, StringLiteral(value: "Hello"))],
                     trailingClosure: nil
-                )
+                ))
             ],
             condition: BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "<", rightOperand: IntegerLiteral(value: 42))
         ).javaScript(with: 1), "    repeat {\n        console.log(\"Hello\");\n    } while (foo < 42)\n")
@@ -91,11 +91,11 @@ class StatementsTests: XCTestCase {
         XCTAssertEqual(IfStatement(
             condition: .boolean(BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "<", rightOperand: IntegerLiteral(value: 42))),
             statements: [
-                FunctionCallExpression(
+                ExprStatement(FunctionCallExpression(
                     expression: IdentifierExpression(identifier: "print"),
                     arguments: [(nil, StringLiteral(value: "Hello"))],
                     trailingClosure: nil
-                )
+                ))
             ],
             elseClause: nil
         ).javaScript(with: 0), "if (foo < 42) {\n    console.log(\"Hello\");\n}\n")
@@ -104,18 +104,18 @@ class StatementsTests: XCTestCase {
         XCTAssertEqual(IfStatement(
             condition: .boolean(BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "<", rightOperand: IntegerLiteral(value: 42))),
             statements: [
-                FunctionCallExpression(
+                ExprStatement(FunctionCallExpression(
                     expression: IdentifierExpression(identifier: "print"),
                     arguments: [(nil, StringLiteral(value: "Hello"))],
                     trailingClosure: nil
-                )
+                ))
             ],
             elseClause: .else_([
-                FunctionCallExpression(
+                ExprStatement(FunctionCallExpression(
                     expression: IdentifierExpression(identifier: "print"),
                     arguments: [(nil, StringLiteral(value: "Bye"))],
                     trailingClosure: nil
-                )
+                ))
             ])
         ).javaScript(with: 0), "if (foo < 42) {\n    console.log(\"Hello\");\n} else {\n    console.log(\"Bye\");\n}\n")
         
@@ -123,20 +123,20 @@ class StatementsTests: XCTestCase {
         XCTAssertEqual(IfStatement(
             condition: .boolean(BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "<", rightOperand: IntegerLiteral(value: 42))),
             statements: [
-                FunctionCallExpression(
+                ExprStatement(FunctionCallExpression(
                     expression: IdentifierExpression(identifier: "print"),
                     arguments: [(nil, StringLiteral(value: "Hello"))],
                     trailingClosure: nil
-                )
+                ))
             ],
             elseClause: .elseIf(IfStatement(
                 condition: .boolean(BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "==", rightOperand: IntegerLiteral(value: 0))),
                 statements: [
-                    FunctionCallExpression(
+                    ExprStatement(FunctionCallExpression(
                         expression: IdentifierExpression(identifier: "print"),
                         arguments: [(nil, StringLiteral(value: "Bye"))],
                         trailingClosure: nil
-                    ),
+                    )),
                 ],
                 elseClause: nil
             ))
@@ -146,20 +146,20 @@ class StatementsTests: XCTestCase {
         XCTAssertEqual(IfStatement(
             condition: .boolean(BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "<", rightOperand: IntegerLiteral(value: 42))),
             statements: [
-                FunctionCallExpression(
+                ExprStatement(FunctionCallExpression(
                     expression: IdentifierExpression(identifier: "print"),
                     arguments: [(nil, StringLiteral(value: "Hello"))],
                     trailingClosure: nil
-                )
+                ))
             ],
             elseClause: .elseIf(IfStatement(
                 condition: .boolean(BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "==", rightOperand: IntegerLiteral(value: 0))),
                 statements: [
-                    FunctionCallExpression(
+                    ExprStatement(FunctionCallExpression(
                         expression: IdentifierExpression(identifier: "print"),
                         arguments: [(nil, StringLiteral(value: "Bye"))],
                         trailingClosure: nil
-                    ),
+                    )),
                     ],
                 elseClause: nil
             ))
@@ -169,7 +169,7 @@ class StatementsTests: XCTestCase {
         XCTAssertEqual(IfStatement(
             condition: .optionalBinding(false, "foo", IdentifierExpression(identifier: "bar")),
             statements: [
-                FunctionCallExpression(expression: IdentifierExpression(identifier: "print"), arguments: [(nil, IdentifierExpression(identifier: "foo"))], trailingClosure: nil),
+                ExprStatement(FunctionCallExpression(expression: IdentifierExpression(identifier: "print"), arguments: [(nil, IdentifierExpression(identifier: "foo"))], trailingClosure: nil)),
             ],
             elseClause: nil
         ).javaScript(with: 0), "{\n    let foo;\n    if ((foo = bar) != null) {\n        console.log(foo);\n    }\n}\n")
@@ -178,7 +178,7 @@ class StatementsTests: XCTestCase {
         XCTAssertEqual(IfStatement(
             condition: .optionalBinding(false, "foo", IdentifierExpression(identifier: "foo")),
             statements: [
-                FunctionCallExpression(expression: IdentifierExpression(identifier: "print"), arguments: [(nil, IdentifierExpression(identifier: "foo"))], trailingClosure: nil),
+                ExprStatement(FunctionCallExpression(expression: IdentifierExpression(identifier: "print"), arguments: [(nil, IdentifierExpression(identifier: "foo"))], trailingClosure: nil)),
                 ],
             elseClause: nil
         ).javaScript(with: 0), "if (foo != null) {\n    console.log(foo);\n}\n")
@@ -293,11 +293,11 @@ class StatementsTests: XCTestCase {
     func testDoStatement() {
         XCTAssertEqual(DoStatement(
             statements: [
-                FunctionCallExpression(
+                ExprStatement(FunctionCallExpression(
                     expression: IdentifierExpression(identifier: "print"),
                     arguments: [(nil, StringLiteral(value: "Hello"))],
                     trailingClosure: nil
-                )
+                ))
             ],
             catchClauses: []
         ).javaScript(with: 0), "{\n    console.log(\"Hello\");\n}\n")
@@ -306,11 +306,11 @@ class StatementsTests: XCTestCase {
         // indent
         XCTAssertEqual(DoStatement(
             statements: [
-                FunctionCallExpression(
+                ExprStatement(FunctionCallExpression(
                     expression: IdentifierExpression(identifier: "print"),
                     arguments: [(nil, StringLiteral(value: "Hello"))],
                     trailingClosure: nil
-                )
+                ))
             ],
             catchClauses: []
         ).javaScript(with: 1), "    {\n        console.log(\"Hello\");\n    }\n")


### PR DESCRIPTION
Instead, introduce `ExprStatement` for `Expression` as a `Statement`, `DeclStatement` for `Declaration` as a `Statement` .
This PR isolates protocol hieracrhy.

@koher What do you think?