### PR TITLE
[AST] Remove SOFT HYPHEN(U+00AD, UTF8: 0xC2 0xAD) from the codebase

### DIFF
--- a/Sources/ASTVisitor.swift
+++ b/Sources/ASTVisitor.swift
@@ -114,16 +114,16 @@ public protocol DeclarationVisitor {
     func visit(_: VariableDeclaration) throws -> DeclarationResult
     func visit(_: TypeAliasDeclaration) throws -> DeclarationResult
     func visit(_: FunctionDeclaration) throws -> DeclarationResult
-    func visit(_: EnumDeclaration­) throws -> DeclarationResult
-    func visit(_: StructDeclaration­) throws -> DeclarationResult
-    func visit(_: ClassDeclaration­) throws -> DeclarationResult
-    func visit(_: ProtocolDeclaration­) throws -> DeclarationResult
-    func visit(_: InitializerDeclaration­) throws -> DeclarationResult
-    func visit(_: DeinitializerDeclaration­) throws -> DeclarationResult
-    func visit(_: ExtensionDeclaration­) throws -> DeclarationResult
-    func visit(_: SubscriptDeclaration­) throws -> DeclarationResult
-    func visit(_: OperatorDeclaration­) throws -> DeclarationResult
-    func visit(_: PrecedenceGroupDeclaration­) throws -> DeclarationResult
+    func visit(_: EnumDeclaration) throws -> DeclarationResult
+    func visit(_: StructDeclaration) throws -> DeclarationResult
+    func visit(_: ClassDeclaration) throws -> DeclarationResult
+    func visit(_: ProtocolDeclaration) throws -> DeclarationResult
+    func visit(_: InitializerDeclaration) throws -> DeclarationResult
+    func visit(_: DeinitializerDeclaration) throws -> DeclarationResult
+    func visit(_: ExtensionDeclaration) throws -> DeclarationResult
+    func visit(_: SubscriptDeclaration) throws -> DeclarationResult
+    func visit(_: OperatorDeclaration) throws -> DeclarationResult
+    func visit(_: PrecedenceGroupDeclaration) throws -> DeclarationResult
 }
 
 extension ImportDeclaration {
@@ -141,34 +141,34 @@ extension TypeAliasDeclaration {
 extension FunctionDeclaration {
     public func accept<V : DeclarationVisitor>(_ v: V) throws -> V.DeclarationResult { return try v.visit(self) }
 }
-extension EnumDeclaration­ {
+extension EnumDeclaration {
     public func accept<V : DeclarationVisitor>(_ v: V) throws -> V.DeclarationResult { return try v.visit(self) }
 }
-extension StructDeclaration­ {
+extension StructDeclaration {
     public func accept<V : DeclarationVisitor>(_ v: V) throws -> V.DeclarationResult { return try v.visit(self) }
 }
-extension ClassDeclaration­ {
+extension ClassDeclaration {
     public func accept<V : DeclarationVisitor>(_ v: V) throws -> V.DeclarationResult { return try v.visit(self) }
 }
-extension ProtocolDeclaration­ {
+extension ProtocolDeclaration {
     public func accept<V : DeclarationVisitor>(_ v: V) throws -> V.DeclarationResult { return try v.visit(self) }
 }
-extension InitializerDeclaration­ {
+extension InitializerDeclaration {
     public func accept<V : DeclarationVisitor>(_ v: V) throws -> V.DeclarationResult { return try v.visit(self) }
 }
-extension DeinitializerDeclaration­ {
+extension DeinitializerDeclaration {
     public func accept<V : DeclarationVisitor>(_ v: V) throws -> V.DeclarationResult { return try v.visit(self) }
 }
-extension ExtensionDeclaration­ {
+extension ExtensionDeclaration {
     public func accept<V : DeclarationVisitor>(_ v: V) throws -> V.DeclarationResult { return try v.visit(self) }
 }
-extension SubscriptDeclaration­ {
+extension SubscriptDeclaration {
     public func accept<V : DeclarationVisitor>(_ v: V) throws -> V.DeclarationResult { return try v.visit(self) }
 }
-extension OperatorDeclaration­ {
+extension OperatorDeclaration {
     public func accept<V : DeclarationVisitor>(_ v: V) throws -> V.DeclarationResult { return try v.visit(self) }
 }
-extension PrecedenceGroupDeclaration­ {
+extension PrecedenceGroupDeclaration {
     public func accept<V : DeclarationVisitor>(_ v: V) throws -> V.DeclarationResult { return try v.visit(self) }
 }
 
@@ -248,7 +248,7 @@ public protocol TypeVisitor {
     func visit(_: ArrayType) throws -> TypeResult
     func visit(_: DictionaryType) throws -> TypeResult
     func visit(_: FunctionType) throws -> TypeResult
-    func visit(_: TypeIdentifier­) throws -> TypeResult
+    func visit(_: TypeIdentifier) throws -> TypeResult
     func visit(_: TupleType) throws -> TypeResult
     func visit(_: OptionalType) throws -> TypeResult
     func visit(_: ImplicitlyUnwrappedOptionalType) throws -> TypeResult
@@ -264,7 +264,7 @@ extension DictionaryType {
 extension FunctionType {
     public func accept<V : TypeVisitor>(_ v: V) throws -> V.TypeResult { return try v.visit(self) }
 }
-extension TypeIdentifier­ {
+extension TypeIdentifier {
     public func accept<V : TypeVisitor>(_ v: V) throws -> V.TypeResult { return try v.visit(self) }
 }
 extension TupleType {

--- a/Sources/Declarations.swift
+++ b/Sources/Declarations.swift
@@ -45,56 +45,56 @@ public struct FunctionDeclaration: Declaration {
 }
 
 
-public struct EnumDeclaration­: Declaration {
+public struct EnumDeclaration: Declaration {
     // Unsupported
 }
 
 
-public struct StructDeclaration­: Declaration {
+public struct StructDeclaration: Declaration {
     // Unsupported
 }
 
 
-public struct ClassDeclaration­: Declaration {
+public struct ClassDeclaration: Declaration {
     public var name: String
     public var superTypes: [Type_]
     public var members: [Declaration]
 }
 
 
-public struct ProtocolDeclaration­: Declaration {
+public struct ProtocolDeclaration: Declaration {
     public var name: String
     // Only `name` is used
 }
 
 
-public struct InitializerDeclaration­: Declaration {
+public struct InitializerDeclaration: Declaration {
     public var arguments: [Parameter]
     public var isFailable: Bool
     public var hasThrows: Bool
     public var body: [Statement]?
 }
 
-public struct DeinitializerDeclaration­: Declaration {
+public struct DeinitializerDeclaration: Declaration {
     // Unsupported
 }
 
 
-public struct ExtensionDeclaration­: Declaration {
+public struct ExtensionDeclaration: Declaration {
     // TODO
 }
 
 
-public struct SubscriptDeclaration­: Declaration {
+public struct SubscriptDeclaration: Declaration {
     // Unsupported
 }
 
 
-public struct OperatorDeclaration­: Declaration {
+public struct OperatorDeclaration: Declaration {
     // Unsupported
 }
 
 
-public struct PrecedenceGroupDeclaration­: Declaration {
+public struct PrecedenceGroupDeclaration: Declaration {
     // Unsupported
 }

--- a/Sources/ParseDecl.swift
+++ b/Sources/ParseDecl.swift
@@ -125,18 +125,18 @@ fileprivate func _declMembers() -> SwiftParser<[Declaration]> {
     return l_brace *> OWS *> sepEndBy(decl, stmtSep) <* OWS <* r_brace
 }
 
-func _declEnum() -> SwiftParser<EnumDeclaration­> {
+func _declEnum() -> SwiftParser<EnumDeclaration> {
     return fail("not implemented")
 }
 
-func _declStruct() -> SwiftParser<StructDeclaration­> {
+func _declStruct() -> SwiftParser<StructDeclaration> {
     return fail("not implemented")
 }
 
 let declClass = _declClass()
-func _declClass() -> SwiftParser<ClassDeclaration­> {
+func _declClass() -> SwiftParser<ClassDeclaration> {
     return { name in { generics in { inherits in { whereClause in { members in
-        ClassDeclaration­(name: name, superTypes: inherits ?? [], members: members) }}}}}
+        ClassDeclaration(name: name, superTypes: inherits ?? [], members: members) }}}}}
         <^> (kw_class *> WS *> identifier)
         <*> zeroOrOne(OWS *> declGenericParams)
         <*> zeroOrOne(OWS *> colon *> OWS *> sepBy1(type, OWS *> comma <* OWS))
@@ -144,12 +144,12 @@ func _declClass() -> SwiftParser<ClassDeclaration­> {
         <*> (OWS *> declMembers)
 }
 
-func _declProtocol() -> SwiftParser<ProtocolDeclaration­> {
+func _declProtocol() -> SwiftParser<ProtocolDeclaration> {
     return fail("not implemented")
 }
 
 let declInitializer = _declInitializer()
-func _declInitializer() -> SwiftParser<InitializerDeclaration­> {
+func _declInitializer() -> SwiftParser<InitializerDeclaration> {
     struct Signature {
         let generics: [GenericParam]?
         let params: [Parameter]
@@ -165,16 +165,16 @@ func _declInitializer() -> SwiftParser<InitializerDeclaration­> {
         <*> zeroOrOne(OWS *> declGenericWhere)
     
     return  { isFailable in { signature in { body in
-        InitializerDeclaration­(arguments: signature.params, isFailable: isFailable != nil, hasThrows: signature.hasThrows, body: body) }}}
+        InitializerDeclaration(arguments: signature.params, isFailable: isFailable != nil, hasThrows: signature.hasThrows, body: body) }}}
         <^> (kw_init *> zeroOrOne(char("?")))
         <*> signature
         <*> (OWS *> stmtBrace)
 }
 
-func _declDeinitializer() -> SwiftParser<DeinitializerDeclaration­> {
+func _declDeinitializer() -> SwiftParser<DeinitializerDeclaration> {
     return fail("not implemented")
 }
 
-func _declExtension() -> SwiftParser<ExtensionDeclaration­> {
+func _declExtension() -> SwiftParser<ExtensionDeclaration> {
     return fail("not implemented")
 }

--- a/Sources/ParseType.swift
+++ b/Sources/ParseType.swift
@@ -47,9 +47,9 @@ func typeSuffix(base: Type_) -> SwiftParser<Type_> {
 }
 
 let typeIdent = _typeIdent()
-func _typeIdent() -> SwiftParser<TypeIdentifier­> {
+func _typeIdent() -> SwiftParser<TypeIdentifier> {
     return { name in
-        TypeIdentifier­(names: [name]) }
+        TypeIdentifier(names: [name]) }
         <^> identifier
 }
 

--- a/Sources/TranslateDeclarations.swift
+++ b/Sources/TranslateDeclarations.swift
@@ -43,7 +43,7 @@ extension FunctionDeclaration {
     }
 }
 
-extension ClassDeclaration­ {
+extension ClassDeclaration {
     public func javaScript(with indentLevel: Int) -> String {
         let propertiesWithInitialValues = members.filter {
             switch $0 {
@@ -57,7 +57,7 @@ extension ClassDeclaration­ {
         }
         let membersExcludingProperties = members.filter { !($0 is VariableDeclaration || $0 is ConstantDeclaration) }
         let adjustedMembers = membersExcludingProperties.map { member -> Declaration in
-            guard var initializer = member as? InitializerDeclaration­ else {
+            guard var initializer = member as? InitializerDeclaration else {
                 return member
             }
             
@@ -102,7 +102,7 @@ extension ClassDeclaration­ {
     }
 }
 
-extension InitializerDeclaration­ {
+extension InitializerDeclaration {
     public func javaScript(with indentLevel: Int) -> String {
         let jsArguments: [String] = arguments.map { param in
             if let initialValue = param.defaultArgument {

--- a/Sources/Types.swift
+++ b/Sources/Types.swift
@@ -16,7 +16,7 @@ public struct FunctionType: Type_ {
     public var returnType: Type_
 }
 
-public struct TypeIdentifier­: Type_ {
+public struct TypeIdentifier: Type_ {
     public var names: [String]
 }
 

--- a/Tests/SwiftScriptTests/DeclarationsTests.swift
+++ b/Tests/SwiftScriptTests/DeclarationsTests.swift
@@ -3,17 +3,17 @@ import XCTest
 
 class DeclarationsTests: XCTestCase {
     func testConstantDeclaration() {
-        XCTAssertEqual(ConstantDeclaration(isStatic: false, name: "foo", type: TypeIdentifier­(names: ["Int"]), expression: IntegerLiteral(value: 42)).javaScript(with: 0), "const foo = 42;\n")
+        XCTAssertEqual(ConstantDeclaration(isStatic: false, name: "foo", type: TypeIdentifier(names: ["Int"]), expression: IntegerLiteral(value: 42)).javaScript(with: 0), "const foo = 42;\n")
 
         // types
-        XCTAssertEqual(ConstantDeclaration(isStatic: false, name: "foo", type: OptionalType(type: TypeIdentifier­(names: ["Int"])), expression: IntegerLiteral(value: 42)).javaScript(with: 0), "const foo = 42;\n")
+        XCTAssertEqual(ConstantDeclaration(isStatic: false, name: "foo", type: OptionalType(type: TypeIdentifier(names: ["Int"])), expression: IntegerLiteral(value: 42)).javaScript(with: 0), "const foo = 42;\n")
     }
     
     func testVariabletDeclaration() {
-        XCTAssertEqual(VariableDeclaration(isStatic: false, name: "foo", type: TypeIdentifier­(names: ["Int"]), expression: IntegerLiteral(value: 42)).javaScript(with: 0), "let foo = 42;\n")
+        XCTAssertEqual(VariableDeclaration(isStatic: false, name: "foo", type: TypeIdentifier(names: ["Int"]), expression: IntegerLiteral(value: 42)).javaScript(with: 0), "let foo = 42;\n")
         
         // types
-        XCTAssertEqual(VariableDeclaration(isStatic: false, name: "foo", type: OptionalType(type: TypeIdentifier­(names: ["Int"])), expression: IntegerLiteral(value: 42)).javaScript(with: 0), "let foo = 42;\n")
+        XCTAssertEqual(VariableDeclaration(isStatic: false, name: "foo", type: OptionalType(type: TypeIdentifier(names: ["Int"])), expression: IntegerLiteral(value: 42)).javaScript(with: 0), "let foo = 42;\n")
     }
     
     func testTypeAliasDeclaration() {
@@ -48,13 +48,13 @@ class DeclarationsTests: XCTestCase {
                 Parameter(
                     externalParameterName: nil,
                     localParameterName: "bar",
-                    type: TypeIdentifier­(names: ["Int"]),
+                    type: TypeIdentifier(names: ["Int"]),
                     defaultArgument: nil
                 ),
                 Parameter(
                     externalParameterName: nil,
                     localParameterName: "baz",
-                    type: TypeIdentifier­(names: ["String"]),
+                    type: TypeIdentifier(names: ["String"]),
                     defaultArgument: nil
                 ),
             ],
@@ -71,17 +71,17 @@ class DeclarationsTests: XCTestCase {
                 Parameter(
                     externalParameterName: "bar",
                     localParameterName: "x",
-                    type: TypeIdentifier­(names: ["Int"]),
+                    type: TypeIdentifier(names: ["Int"]),
                     defaultArgument: nil
                 ),
                 Parameter(
                     externalParameterName: "baz",
                     localParameterName: "y",
-                    type: TypeIdentifier­(names: ["String"]),
+                    type: TypeIdentifier(names: ["String"]),
                     defaultArgument: nil
                 ),
             ],
-            result: TypeIdentifier­(names: ["Void"]),
+            result: TypeIdentifier(names: ["Void"]),
             hasThrows: true,
             body: []
         ).javaScript(with: 0), "function foo(x, y) {\n}\n")
@@ -94,13 +94,13 @@ class DeclarationsTests: XCTestCase {
                 Parameter(
                     externalParameterName: nil,
                     localParameterName: "x",
-                    type: TypeIdentifier­(names: ["Int"]),
+                    type: TypeIdentifier(names: ["Int"]),
                     defaultArgument: nil
                 ),
                 Parameter(
                     externalParameterName: nil,
                     localParameterName: "y",
-                    type: TypeIdentifier­(names: ["Int"]),
+                    type: TypeIdentifier(names: ["Int"]),
                     defaultArgument: nil
                 ),
             ],
@@ -123,13 +123,13 @@ class DeclarationsTests: XCTestCase {
                 Parameter(
                     externalParameterName: nil,
                     localParameterName: "x",
-                    type: TypeIdentifier­(names: ["Int"]),
+                    type: TypeIdentifier(names: ["Int"]),
                     defaultArgument: nil
                 ),
                 Parameter(
                     externalParameterName: nil,
                     localParameterName: "y",
-                    type: TypeIdentifier­(names: ["Int"]),
+                    type: TypeIdentifier(names: ["Int"]),
                     defaultArgument: nil
                 ),
             ],
@@ -145,22 +145,22 @@ class DeclarationsTests: XCTestCase {
         ).javaScript(with: 1), "    function foo(x, y) {\n        return x + y;\n    }\n")
     }
     
-    func testClassDeclaration­() {
-        XCTAssertEqual(ClassDeclaration­(
+    func testClassDeclaration() {
+        XCTAssertEqual(ClassDeclaration(
             name: "Foo",
             superTypes: [],
             members: []
         ).javaScript(with: 0), "class Foo {\n}\n")
         
         // properties
-        XCTAssertEqual(ClassDeclaration­(
+        XCTAssertEqual(ClassDeclaration(
             name: "Foo",
             superTypes: [],
             members: [
                 VariableDeclaration(
                     isStatic: false,
                     name: "bar",
-                    type: TypeIdentifier­(names: ["Int"]),
+                    type: TypeIdentifier(names: ["Int"]),
                     expression: nil
                 ),
                 ConstantDeclaration(
@@ -169,12 +169,12 @@ class DeclarationsTests: XCTestCase {
                     type: nil,
                     expression: StringLiteral(value: "xyz")
                 ),
-                InitializerDeclaration­(
+                InitializerDeclaration(
                     arguments: [
                         Parameter(
                             externalParameterName: nil,
                             localParameterName: "bar",
-                            type: TypeIdentifier­(names: ["Int"]),
+                            type: TypeIdentifier(names: ["Int"]),
                             defaultArgument: nil
                         ),
                     ],
@@ -195,7 +195,7 @@ class DeclarationsTests: XCTestCase {
         ).javaScript(with: 0), "class Foo {\n    constructor(bar) {\n        this.bar = 42;\n        this.baz = \"xyz\";\n    }\n}\n")
         
         // methods
-        XCTAssertEqual(ClassDeclaration­(
+        XCTAssertEqual(ClassDeclaration(
             name: "Foo",
             superTypes: [],
             members: [
@@ -211,14 +211,14 @@ class DeclarationsTests: XCTestCase {
         ).javaScript(with: 0), "class Foo {\n    bar() {\n    }\n}\n")
         
         // indentLevel + 1
-        XCTAssertEqual(ClassDeclaration­(
+        XCTAssertEqual(ClassDeclaration(
             name: "Foo",
             superTypes: [],
             members: [
                 VariableDeclaration(
                     isStatic: false,
                     name: "bar",
-                    type: TypeIdentifier­(names: ["Int"]),
+                    type: TypeIdentifier(names: ["Int"]),
                     expression: nil
                 ),
                 ConstantDeclaration(
@@ -227,12 +227,12 @@ class DeclarationsTests: XCTestCase {
                     type: nil,
                     expression: StringLiteral(value: "xyz")
                 ),
-                InitializerDeclaration­(
+                InitializerDeclaration(
                     arguments: [
                         Parameter(
                             externalParameterName: nil,
                             localParameterName: "bar",
-                            type: TypeIdentifier­(names: ["Int"]),
+                            type: TypeIdentifier(names: ["Int"]),
                             defaultArgument: nil
                         ),
                     ],
@@ -253,8 +253,8 @@ class DeclarationsTests: XCTestCase {
             ).javaScript(with: 1), "    class Foo {\n        constructor(bar) {\n            this.bar = 42;\n            this.baz = \"xyz\";\n        }\n    }\n")
     }
     
-    func testInitializerDeclaration­() {
-        XCTAssertEqual(InitializerDeclaration­(
+    func testInitializerDeclaration() {
+        XCTAssertEqual(InitializerDeclaration(
             arguments: [],
             isFailable: false,
             hasThrows: false,
@@ -268,18 +268,18 @@ class DeclarationsTests: XCTestCase {
         ).javaScript(with: 0), "constructor() {\n    this.foo = 42;\n}\n")
         
         // arguments
-        XCTAssertEqual(InitializerDeclaration­(
+        XCTAssertEqual(InitializerDeclaration(
             arguments: [
                 Parameter(
                     externalParameterName: nil,
                     localParameterName: "bar",
-                    type: TypeIdentifier­(names: ["Int"]),
+                    type: TypeIdentifier(names: ["Int"]),
                     defaultArgument: nil
                 ),
                 Parameter(
                     externalParameterName: nil,
                     localParameterName: "baz",
-                    type: TypeIdentifier­(names: ["String"]),
+                    type: TypeIdentifier(names: ["String"]),
                     defaultArgument: nil
                 ),
             ],
@@ -299,7 +299,7 @@ class DeclarationsTests: XCTestCase {
         ).javaScript(with: 0), "constructor(bar, baz) {\n    this.foo = bar + baz;\n}\n")
         
         // indent
-        XCTAssertEqual(InitializerDeclaration­(
+        XCTAssertEqual(InitializerDeclaration(
             arguments: [],
             isFailable: false,
             hasThrows: false,

--- a/Tests/SwiftScriptTests/ExpressionsTest.swift
+++ b/Tests/SwiftScriptTests/ExpressionsTest.swift
@@ -36,7 +36,7 @@ class ExpressionsTests: XCTestCase {
             hasThrows: false,
             result: nil,
             statements: [
-                DeclarationStatement(ConstantDeclaration(isStatic: false, name: "foo", type: TypeIdentifier­(names: ["Int"]), expression: IntegerLiteral(value: 42))),
+                DeclarationStatement(ConstantDeclaration(isStatic: false, name: "foo", type: TypeIdentifier(names: ["Int"]), expression: IntegerLiteral(value: 42))),
                 ReturnStatement(expression: IdentifierExpression(identifier: "foo"))
             ]
         ).javaScript(with: 0), "() => {\n    const foo = 42;\n    return foo;\n}")
@@ -47,7 +47,7 @@ class ExpressionsTests: XCTestCase {
             hasThrows: false,
             result: nil,
             statements: [
-                DeclarationStatement(ConstantDeclaration(isStatic: false, name: "foo", type: TypeIdentifier­(names: ["Int"]), expression: IntegerLiteral(value: 42))),
+                DeclarationStatement(ConstantDeclaration(isStatic: false, name: "foo", type: TypeIdentifier(names: ["Int"]), expression: IntegerLiteral(value: 42))),
                 ReturnStatement(expression: IdentifierExpression(identifier: "foo"))
             ]
         ).javaScript(with: 1), "() => {\n        const foo = 42;\n        return foo;\n    }")
@@ -74,9 +74,9 @@ class ExpressionsTests: XCTestCase {
         
         // arguments with types
         XCTAssertEqual(ClosureExpression(
-            arguments: [("x", TypeIdentifier­(names: ["Int"])), ("y", TypeIdentifier­(names: ["Int"]))],
+            arguments: [("x", TypeIdentifier(names: ["Int"])), ("y", TypeIdentifier(names: ["Int"]))],
             hasThrows: false,
-            result: TypeIdentifier­(names: ["Int"]),
+            result: TypeIdentifier(names: ["Int"]),
             statements: [ExpressionStatement(BinaryOperation(
                 leftOperand: IdentifierExpression(identifier: "x"),
                 operatorSymbol: "+",

--- a/Tests/SwiftScriptTests/NodeEquatable.swift
+++ b/Tests/SwiftScriptTests/NodeEquatable.swift
@@ -86,16 +86,16 @@ struct DeclarationEqual: DeclarationVisitor {
     func visit(_ lhs: VariableDeclaration) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
     func visit(_ lhs: TypeAliasDeclaration) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
     func visit(_ lhs: FunctionDeclaration) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
-    func visit(_ lhs: EnumDeclaration­) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
-    func visit(_ lhs: StructDeclaration­) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
-    func visit(_ lhs: ClassDeclaration­) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
-    func visit(_ lhs: ProtocolDeclaration­) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
-    func visit(_ lhs: InitializerDeclaration­) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
-    func visit(_ lhs: DeinitializerDeclaration­) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
-    func visit(_ lhs: ExtensionDeclaration­) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
-    func visit(_ lhs: SubscriptDeclaration­) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
-    func visit(_ lhs: OperatorDeclaration­) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
-    func visit(_ lhs: PrecedenceGroupDeclaration­) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
+    func visit(_ lhs: EnumDeclaration) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
+    func visit(_ lhs: StructDeclaration) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
+    func visit(_ lhs: ClassDeclaration) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
+    func visit(_ lhs: ProtocolDeclaration) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
+    func visit(_ lhs: InitializerDeclaration) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
+    func visit(_ lhs: DeinitializerDeclaration) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
+    func visit(_ lhs: ExtensionDeclaration) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
+    func visit(_ lhs: SubscriptDeclaration) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
+    func visit(_ lhs: OperatorDeclaration) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
+    func visit(_ lhs: PrecedenceGroupDeclaration) -> (Declaration) -> Bool { return sameTypeAndEqual(to: lhs) }
 }
 
 struct StatementEqual : StatementVisitor {
@@ -152,7 +152,7 @@ struct TypeEqual : TypeVisitor {
     func visit(_ lhs: ArrayType) -> (Type_) -> Bool { return sameTypeAndEqual(to: lhs) }
     func visit(_ lhs: DictionaryType) -> (Type_) -> Bool { return sameTypeAndEqual(to: lhs) }
     func visit(_ lhs: FunctionType) -> (Type_) -> Bool { return sameTypeAndEqual(to: lhs) }
-    func visit(_ lhs: TypeIdentifier­) -> (Type_) -> Bool { return sameTypeAndEqual(to: lhs) }
+    func visit(_ lhs: TypeIdentifier) -> (Type_) -> Bool { return sameTypeAndEqual(to: lhs) }
     func visit(_ lhs: TupleType) -> (Type_) -> Bool { return sameTypeAndEqual(to: lhs) }
     func visit(_ lhs: OptionalType) -> (Type_) -> Bool { return sameTypeAndEqual(to: lhs) }
     func visit(_ lhs: ImplicitlyUnwrappedOptionalType) -> (Type_) -> Bool { return sameTypeAndEqual(to: lhs) }
@@ -229,58 +229,58 @@ extension FunctionDeclaration : Equatable {
             && lhs.arguments == rhs.arguments
     }
 }
-extension EnumDeclaration­ : Equatable {
-    public static func == (lhs: EnumDeclaration­, rhs: EnumDeclaration­) -> Bool {
+extension EnumDeclaration : Equatable {
+    public static func == (lhs: EnumDeclaration, rhs: EnumDeclaration) -> Bool {
         fatalError("unsupported")
     }
 }
-extension StructDeclaration­ : Equatable {
-    public static func == (lhs: StructDeclaration­, rhs: StructDeclaration­) -> Bool {
+extension StructDeclaration : Equatable {
+    public static func == (lhs: StructDeclaration, rhs: StructDeclaration) -> Bool {
         fatalError("unsupported")
     }
 }
-extension ClassDeclaration­ : Equatable {
-    public static func == (lhs: ClassDeclaration­, rhs: ClassDeclaration­) -> Bool {
+extension ClassDeclaration : Equatable {
+    public static func == (lhs: ClassDeclaration, rhs: ClassDeclaration) -> Bool {
         return lhs.name == rhs.name
             && lhs.superTypes == rhs.superTypes
             && lhs.members == rhs.members
     }
 }
-extension ProtocolDeclaration­ : Equatable {
-    public static func == (lhs: ProtocolDeclaration­, rhs: ProtocolDeclaration­) -> Bool {
+extension ProtocolDeclaration : Equatable {
+    public static func == (lhs: ProtocolDeclaration, rhs: ProtocolDeclaration) -> Bool {
         return lhs.name == rhs.name
     }
 }
-extension InitializerDeclaration­ : Equatable {
-    public static func == (lhs: InitializerDeclaration­, rhs: InitializerDeclaration­) -> Bool {
+extension InitializerDeclaration : Equatable {
+    public static func == (lhs: InitializerDeclaration, rhs: InitializerDeclaration) -> Bool {
         return lhs.arguments == rhs.arguments
             && lhs.isFailable == rhs.isFailable
             && lhs.hasThrows == rhs.hasThrows
             && lhs.body == rhs.body
     }
 }
-extension DeinitializerDeclaration­ : Equatable {
-    public static func == (lhs: DeinitializerDeclaration­, rhs: DeinitializerDeclaration­) -> Bool {
+extension DeinitializerDeclaration : Equatable {
+    public static func == (lhs: DeinitializerDeclaration, rhs: DeinitializerDeclaration) -> Bool {
         fatalError("unsupported")
     }
 }
-extension ExtensionDeclaration­ : Equatable {
-    public static func == (lhs: ExtensionDeclaration­, rhs: ExtensionDeclaration­) -> Bool {
+extension ExtensionDeclaration : Equatable {
+    public static func == (lhs: ExtensionDeclaration, rhs: ExtensionDeclaration) -> Bool {
         fatalError("unsupported")
     }
 }
-extension SubscriptDeclaration­ : Equatable {
-    public static func == (lhs: SubscriptDeclaration­, rhs: SubscriptDeclaration­) -> Bool {
+extension SubscriptDeclaration : Equatable {
+    public static func == (lhs: SubscriptDeclaration, rhs: SubscriptDeclaration) -> Bool {
         fatalError("unsupported")
     }
 }
-extension OperatorDeclaration­ : Equatable {
-    public static func == (lhs: OperatorDeclaration­, rhs: OperatorDeclaration­) -> Bool {
+extension OperatorDeclaration : Equatable {
+    public static func == (lhs: OperatorDeclaration, rhs: OperatorDeclaration) -> Bool {
         fatalError("unsupported")
     }
 }
-extension PrecedenceGroupDeclaration­ : Equatable {
-    public static func == (lhs: PrecedenceGroupDeclaration­, rhs: PrecedenceGroupDeclaration­) -> Bool {
+extension PrecedenceGroupDeclaration : Equatable {
+    public static func == (lhs: PrecedenceGroupDeclaration, rhs: PrecedenceGroupDeclaration) -> Bool {
         fatalError("unsupported")
     }
 }
@@ -540,8 +540,8 @@ extension FunctionType : Equatable {
             && lhs.returnType == rhs.returnType
     }
 }
-extension TypeIdentifier­ : Equatable {
-    public static func == (lhs: TypeIdentifier­, rhs: TypeIdentifier­) -> Bool {
+extension TypeIdentifier : Equatable {
+    public static func == (lhs: TypeIdentifier, rhs: TypeIdentifier) -> Bool {
         return lhs.names == rhs.names
     }
 }

--- a/Tests/SwiftScriptTests/ParseDeclTests.swift
+++ b/Tests/SwiftScriptTests/ParseDeclTests.swift
@@ -14,17 +14,17 @@ class ParseDeclTests: XCTestCase {
                     Parameter(
                         externalParameterName: nil,
                         localParameterName: "x",
-                        type: TypeIdentifier­.init(names: ["A"]),
+                        type: TypeIdentifier.init(names: ["A"]),
                         defaultArgument: IntegerLiteral(value: 1)
                     ),
                     Parameter(
                         externalParameterName: "x",
                         localParameterName: "y",
-                        type: TypeIdentifier­.init(names: ["B"]),
+                        type: TypeIdentifier.init(names: ["B"]),
                         defaultArgument: nil
                     ),
                 ],
-                result: TypeIdentifier­(names: ["C"]),
+                result: TypeIdentifier(names: ["C"]),
                 hasThrows: true,
                 body: [
                     ReturnStatement(
@@ -44,17 +44,17 @@ class ParseDeclTests: XCTestCase {
                     Parameter(
                         externalParameterName: nil,
                         localParameterName: "x",
-                        type: TypeIdentifier­.init(names: ["A"]),
+                        type: TypeIdentifier.init(names: ["A"]),
                         defaultArgument: IntegerLiteral(value: 1)
                     ),
                     Parameter(
                         externalParameterName: "x",
                         localParameterName: "y",
-                        type: TypeIdentifier­.init(names: ["B"]),
+                        type: TypeIdentifier.init(names: ["B"]),
                         defaultArgument: nil
                     ),
                 ],
-                result: TypeIdentifier­(names: ["C"]),
+                result: TypeIdentifier(names: ["C"]),
                 hasThrows: true,
                 body: [
                     ReturnStatement(
@@ -87,11 +87,11 @@ class ParseDeclTests: XCTestCase {
                     Parameter(
                         externalParameterName: nil,
                         localParameterName: "x",
-                        type: TypeIdentifier­.init(names: ["T"]),
+                        type: TypeIdentifier.init(names: ["T"]),
                         defaultArgument: nil
                     ),
                 ],
-                result: TypeIdentifier­(names: ["C"]),
+                result: TypeIdentifier(names: ["C"]),
                 hasThrows: true,
                 body: []
             )

--- a/Tests/SwiftScriptTests/ParseTypeTests.swift
+++ b/Tests/SwiftScriptTests/ParseTypeTests.swift
@@ -11,12 +11,12 @@ class ParseTypeTests: XCTestCase {
         ParseEqual(
             type,
             "[Foo]",
-            ArrayType(type: TypeIdentifier­(names: ["Foo"]))
+            ArrayType(type: TypeIdentifier(names: ["Foo"]))
         )
         ParseEqual(
             type,
             "[ Foo ]",
-            ArrayType(type: TypeIdentifier­(names: ["Foo"]))
+            ArrayType(type: TypeIdentifier(names: ["Foo"]))
         )
     }
     func testTypeDictionary() {


### PR DESCRIPTION
There were bunch of invisible "SOFT HYPHEN" in type names.
http://unicode.org/cldr/utility/character.jsp?a=00AD
