### PR TITLE
[Translate] Implement `JavaScriptTranslator`

### DIFF
--- a/Sources/JavaScript.swift
+++ b/Sources/JavaScript.swift
@@ -1,3 +1,0 @@
-public protocol JavaScriptConvertible {
-    func javaScript(with indentLevel: Int) -> String
-}

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -1,9 +1,3 @@
 public protocol Node {
     
 }
-
-extension Node {
-    public func javaScript(with indentLevel: Int) -> String {
-        return  "<unimplemented: \(type(of: self))>"
-    }
-}

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -1,4 +1,4 @@
-public protocol Node: JavaScriptConvertible {
+public protocol Node {
     
 }
 

--- a/Sources/TranslateDeclarations.swift
+++ b/Sources/TranslateDeclarations.swift
@@ -10,7 +10,7 @@ extension JavaScriptTranslator {
         }
         
         if let expression = n.expression {
-            return "\(indent(of: indentLevel))const \(n.name) = \(expression.javaScript(with: indentLevel));\n"
+            return "\(indent(of: indentLevel))const \(n.name) = \(try expression.accept(JavaScriptTranslator(indentLevel: indentLevel)));\n"
         } else {
             return "\(indent(of: indentLevel))const \(n.name);\n"
         }
@@ -23,7 +23,7 @@ extension JavaScriptTranslator {
         }
         
         if let expression = n.expression {
-            return "\(indent(of: indentLevel))let \(n.name) = \(expression.javaScript(with: indentLevel));\n"
+            return "\(indent(of: indentLevel))let \(n.name) = \(try expression.accept(JavaScriptTranslator(indentLevel: indentLevel)));\n"
         } else {
             return "\(indent(of: indentLevel))let \(n.name);\n"
         }
@@ -44,7 +44,7 @@ extension JavaScriptTranslator {
         }
         
         // `body!` because `FunctionDeclaration` without `body` is for `protocol`s and thier `javaScript` is never called
-        return "\(indent(of: indentLevel))\(n.isStatic ? "static " : "")function \(n.name)(\(jsArguments.joined(separator: ", "))) \(transpileBlock(statements: n.body!, indentLevel: indentLevel))\n"
+        return "\(indent(of: indentLevel))\(n.isStatic ? "static " : "")function \(n.name)(\(jsArguments.joined(separator: ", "))) \(try transpileBlock(statements: n.body!, indentLevel: indentLevel))\n"
     }
     
     func visit(_: EnumDeclaration) throws -> String {
@@ -95,12 +95,9 @@ extension JavaScriptTranslator {
             return initializer
         }
         
-        let jsMembers: [String] = adjustedMembers.map { member in
-            let js = member.javaScript(with: indentLevel + 1)
+        let jsMembers: [String] = try adjustedMembers.map { member in
+            let js = try member.accept(JavaScriptTranslator(indentLevel: indentLevel + 1))
             guard member is FunctionDeclaration else {
-                if member is Expression {
-                    return "\(indent(of: indentLevel + 1))\(js);\n"
-                }
                 return js
             }
             
@@ -124,7 +121,7 @@ extension JavaScriptTranslator {
             }
         }
         // `body!` because `FunctionDeclaration` without `body` is for `protocol`s and thier `javaScript` is never called
-        return "\(indent(of: indentLevel))constructor(\(jsArguments.joined(separator: ", "))) \(transpileBlock(statements: n.body!, indentLevel: indentLevel))\n"
+        return "\(indent(of: indentLevel))constructor(\(jsArguments.joined(separator: ", "))) \(try transpileBlock(statements: n.body!, indentLevel: indentLevel))\n"
     }
 
     func visit(_: DeinitializerDeclaration) throws -> String {

--- a/Sources/TranslateExpressions.swift
+++ b/Sources/TranslateExpressions.swift
@@ -1,119 +1,117 @@
-extension IdentifierExpression {
-    public func javaScript(with indentLevel: Int) -> String {
-        switch identifier {
-            case "print":
-                return "console.log"
-            case "append":
-                return "push"
-            case "removeLast":
-                return "pop"
-            default:
-                return identifier
+extension JavaScriptTranslator {
+    func visit(_ n: IdentifierExpression) throws -> String {
+        switch n.identifier {
+        case "print":
+            return "console.log"
+        case "append":
+            return "push"
+        case "removeLast":
+            return "pop"
+        default:
+            return n.identifier
         }
     }
-}
-
-extension FunctionCallExpression {
-    public func javaScript(with indentLevel: Int) -> String {
-        if let expression = expression as? PostfixUnaryOperation, expression.operatorSymbol == "?" {
-            var zelf = self
-            zelf.expression = IdentifierExpression(identifier: "x")
-            return optionalChaining(expression.operand, zelf, indentLevel: indentLevel)
+    
+    func visit(_ n: FunctionCallExpression) throws -> String {
+        if let expression = n.expression as? PostfixUnaryOperation, expression.operatorSymbol == "?" {
+            var node = n
+            node.expression = IdentifierExpression(identifier: "x")
+            return optionalChaining(expression.operand, node, indentLevel: indentLevel)
         }
-        var jsArguments: [String] = arguments.map { $1.javaScript(with: indentLevel) }
-        if let closure = trailingClosure {
+        var jsArguments: [String] = n.arguments.map { $1.javaScript(with: indentLevel) }
+        if let closure = n.trailingClosure {
             jsArguments.append(closure.javaScript(with: indentLevel))
         }
         let hasNew: Bool
-        if let firstLetter = ((expression as? IdentifierExpression)?.identifier.characters.first.map { String($0) }) {
+        if let firstLetter = ((n.expression as? IdentifierExpression)?.identifier.characters.first.map { String($0) }) {
             hasNew = firstLetter.uppercased() == firstLetter
         } else {
             hasNew = false
         }
-        var jsExpression: String = "\(hasNew ? "new " : "")\(expression.javaScript(with: indentLevel))"
-        if expression is ClosureExpression {
+        var jsExpression: String = "\(hasNew ? "new " : "")\(n.expression.javaScript(with: indentLevel))"
+        if n.expression is ClosureExpression {
             jsExpression = "(\(jsExpression))"
         }
         return "\(jsExpression)(\(jsArguments.joined(separator: ", ")))"
     }
-}
-
-extension SelfExpression {
-    public func javaScript(with indentLevel: Int) -> String {
+    
+    func visit(_ n: SelfExpression) throws -> String {
         return "this"
     }
-}
-
-extension SuperclassExpression {
-    public func javaScript(with indentLevel: Int) -> String {
+    
+    func visit(_ n: SuperclassExpression) throws -> String {
         return "super"
     }
-}
-
-extension ClosureExpression {
-    public func javaScript(with indentLevel: Int) -> String {
-        let jsArguments: String = arguments.map { $0.0 }.joined(separator: ", ")
-        switch statements.count {
+    
+    func visit(_ n: ClosureExpression) throws -> String {
+        let jsArguments: String = n.arguments.map { $0.0 }.joined(separator: ", ")
+        switch n.statements.count {
         case 0:
             return "(\(jsArguments)) => {}"
         case 1:
-            let statement = statements[0]
+            let statement = n.statements[0]
             if let expressionStatement = statement as? ExpressionStatement {
                 return "(\(jsArguments)) => \(expressionStatement.expression.javaScript(with: indentLevel))"
             } else {
-                return "(\(jsArguments)) => \(transpileBlock(statements: statements, indentLevel: indentLevel))"
+                return "(\(jsArguments)) => \(transpileBlock(statements: n.statements, indentLevel: indentLevel))"
             }
         default:
-            return "(\(jsArguments)) => \(transpileBlock(statements: statements, indentLevel: indentLevel))"
+            return "(\(jsArguments)) => \(transpileBlock(statements: n.statements, indentLevel: indentLevel))"
         }
     }
-}
-
-extension ParenthesizedExpression {
-    public func javaScript(with indentLevel: Int) -> String {
-        return "(\(expression.javaScript(with: indentLevel + 1)))"
+    
+    func visit(_ n: ParenthesizedExpression) throws -> String {
+        return "(\(n.expression.javaScript(with: indentLevel + 1)))"
     }
-}
-
-extension TupleExpression {
-    public func javaScript(with indentLevel: Int) -> String {
-        let values = elements.map { $0.1.javaScript(with: indentLevel + 1) }.joined(separator: ", ")
+    
+    func visit(_ n: TupleExpression) throws -> String {
+        let values = n.elements.map { $0.1.javaScript(with: indentLevel + 1) }.joined(separator: ", ")
         return "[\(values)]"
     }
-}
+    
+    func visit(_: ImplicitMemberExpression) throws -> String {
+        throw UnimplementedError()
+    }
 
-extension WildcardExpression {
-    public func javaScript(with indentLevel: Int) -> String {
+    func visit(_ n: WildcardExpression) throws -> String {
         return "_"
     }
-}
-
-extension ExplicitMemberExpression {
-    public func javaScript(with indentLevel: Int) -> String {
-        if let expression = expression as? PostfixUnaryOperation, expression.operatorSymbol == "?" {
-            var zelf = self
-            zelf.expression = IdentifierExpression(identifier: "x")
-            return optionalChaining(expression.operand, zelf, indentLevel: indentLevel)
-        }
-        if expression is SuperclassExpression, member == "init" {
-            return "\(expression.javaScript(with: indentLevel))"
-        }
-        return "\(expression.javaScript(with: indentLevel)).\(member)"
+    
+    func visit(_: InitializerExpression) throws -> String {
+        throw UnimplementedError()
     }
-}
-
-extension SubscriptExpression {
-    public func javaScript(with indentLevel: Int) -> String {
-        if let expression = expression as? PostfixUnaryOperation, expression.operatorSymbol == "?" {
-            var zelf = self
-            zelf.expression = IdentifierExpression(identifier: "x")
-            return optionalChaining(expression.operand, zelf, indentLevel: indentLevel)
+    
+    func visit(_ n: ExplicitMemberExpression) throws -> String {
+        if let expression = n.expression as? PostfixUnaryOperation, expression.operatorSymbol == "?" {
+            var node = n
+            node.expression = IdentifierExpression(identifier: "x")
+            return optionalChaining(expression.operand, node, indentLevel: indentLevel)
         }
-        var jsExpression = expression.javaScript(with: indentLevel)
-        if expression is ClosureExpression {
+        if n.expression is SuperclassExpression, n.member == "init" {
+            return "\(n.expression.javaScript(with: indentLevel))"
+        }
+        return "\(n.expression.javaScript(with: indentLevel)).\(n.member)"
+    }
+    
+    func visit(_: PostfixSelfExpression) throws -> String {
+        throw UnimplementedError()
+    }
+    
+    func visit(_: DynamicTypeExpression) throws -> String {
+        throw UnimplementedError()
+    }
+
+    func visit(_ n: SubscriptExpression) throws -> String {
+        if let expression = n.expression as? PostfixUnaryOperation, expression.operatorSymbol == "?" {
+            var node = n
+            node.expression = IdentifierExpression(identifier: "x")
+            return optionalChaining(expression.operand, node, indentLevel: indentLevel)
+        }
+        var jsExpression = n.expression.javaScript(with: indentLevel)
+        if n.expression is ClosureExpression {
             jsExpression = "(\(jsExpression))"
         }
-        return "\(jsExpression)[\(arguments.map { $0.javaScript(with: indentLevel) }.joined(separator: ", "))]"
+        return "\(jsExpression)[\(n.arguments.map { $0.javaScript(with: indentLevel) }.joined(separator: ", "))]"
     }
 }
 

--- a/Sources/TranslateLiterals.swift
+++ b/Sources/TranslateLiterals.swift
@@ -1,14 +1,13 @@
 extension JavaScriptTranslator {
     func visit(_ n: ArrayLiteral) throws -> String {
-        let values: String = n.value.map { $0.javaScript(with: indentLevel + 1) }.joined(separator: ", ")
+        let values: String = try n.value.map { try $0.accept(JavaScriptTranslator(indentLevel: indentLevel)) }.joined(separator: ", ")
         return "[\(values)]"
     }
     
     func visit(_ n: DictionaryLiteral) throws -> String {
-        let keyValues: String = n.value.map {
-            "\("    " * (indentLevel + 1))\($0.0.javaScript(with: indentLevel + 1)): \($0.1.javaScript(with: indentLevel + 1))"
-            }.joined(separator: ",\n")
-        
+        let keyValues: String = try n.value.map {
+            "\("    " * (indentLevel + 1))\(try $0.0.accept(JavaScriptTranslator(indentLevel: indentLevel + 1))): \(try $0.1.accept(JavaScriptTranslator(indentLevel: indentLevel + 1)))"
+        }.joined(separator: ",\n")
         
         return "{\n\(keyValues)\n\("    " * indentLevel)}"
     }

--- a/Sources/TranslateLiterals.swift
+++ b/Sources/TranslateLiterals.swift
@@ -1,48 +1,36 @@
-extension IntegerLiteral {
-    public func javaScript(with indentLevel: Int) -> String {
-        return  "\(value)"
+extension JavaScriptTranslator {
+    func visit(_ n: ArrayLiteral) throws -> String {
+        let values: String = n.value.map { $0.javaScript(with: indentLevel + 1) }.joined(separator: ", ")
+        return "[\(values)]"
     }
-}
-
-extension StringLiteral {
-    public func javaScript(with indentLevel: Int) -> String {
-        // TODO: escaping special characters
-        return  "\"\(value)\""
-    }
-}
-
-extension DictionaryLiteral {
-    public func javaScript(with indentLevel: Int) -> String {
-        let keyValues: String = value.map {
+    
+    func visit(_ n: DictionaryLiteral) throws -> String {
+        let keyValues: String = n.value.map {
             "\("    " * (indentLevel + 1))\($0.0.javaScript(with: indentLevel + 1)): \($0.1.javaScript(with: indentLevel + 1))"
-        }.joined(separator: ",\n")
+            }.joined(separator: ",\n")
         
         
         return "{\n\(keyValues)\n\("    " * indentLevel)}"
     }
-}
-
-extension NilLiteral {
-    public func javaScript(with indentLevel: Int) -> String {
+    
+    func visit(_ n: IntegerLiteral) throws -> String {
+        return  "\(n.value)"
+    }
+    
+    func visit(_ n: FloatingPointLiteral) throws -> String {
+        return  "\(n.value)"
+    }
+    
+    func visit(_ n: StringLiteral) throws -> String {
+        // TODO: escaping special characters
+        return  "\"\(n.value)\""
+    }
+    
+    func visit(_ n: BooleanLiteral) throws -> String {
+        return  n.value ? "true" : "false"
+    }
+    
+    func visit(_ n: NilLiteral) throws -> String {
         return  "null"
-    }
-}
-
-extension FloatingPointLiteral {
-    public func javaScript(with indentLevel: Int) -> String {
-        return  "\(value)"
-    }
-}
-
-extension BooleanLiteral {
-    public func javaScript(with indentLevel: Int) -> String {
-        return  value ? "true" : "false"
-    }
-}
-
-extension ArrayLiteral {
-    public func javaScript(with indentLevel: Int) -> String {
-        let values: String = value.map { $0.javaScript(with: indentLevel + 1) }.joined(separator: ", ")
-        return "[\(values)]"
     }
 }

--- a/Sources/TranslateOperations.swift
+++ b/Sources/TranslateOperations.swift
@@ -1,7 +1,7 @@
 extension JavaScriptTranslator {
     func visit(_ n: BinaryOperation) throws -> String {
-        let lhs = n.leftOperand.javaScript(with: indentLevel + 1)
-        let rhs = n.rightOperand.javaScript(with: indentLevel + 1)
+        let lhs = try n.leftOperand.accept(JavaScriptTranslator(indentLevel: indentLevel))
+        let rhs = try n.rightOperand.accept(JavaScriptTranslator(indentLevel: indentLevel))
         switch n.operatorSymbol {
         case "as":
             return lhs
@@ -25,7 +25,7 @@ extension JavaScriptTranslator {
     }
     
     func visit(_ n: PrefixUnaryOperation) throws -> String {
-        let value = n.operand.javaScript(with: indentLevel + 1)
+        let value = try n.operand.accept(JavaScriptTranslator(indentLevel: indentLevel))
         switch n.operatorSymbol {
         case "try":
             return value
@@ -39,7 +39,7 @@ extension JavaScriptTranslator {
     }
     
     func visit(_ n: PostfixUnaryOperation) throws -> String {
-        let value = n.operand.javaScript(with: indentLevel + 1)
+        let value = try n.operand.accept(JavaScriptTranslator(indentLevel: indentLevel))
         switch n.operatorSymbol {
         case "?":
             fatalError("Never reaches here if semantic analysis is implemented.")
@@ -51,9 +51,9 @@ extension JavaScriptTranslator {
     }
     
     func visit(_ n: TernaryOperation) throws -> String {
-        let first = n.firstOperand.javaScript(with: indentLevel + 1)
-        let second = n.secondOperand.javaScript(with: indentLevel + 1)
-        let third = n.thirdOperand.javaScript(with: indentLevel + 1)
+        let first = try n.firstOperand.accept(JavaScriptTranslator(indentLevel: indentLevel))
+        let second = try n.secondOperand.accept(JavaScriptTranslator(indentLevel: indentLevel))
+        let third = try n.thirdOperand.accept(JavaScriptTranslator(indentLevel: indentLevel))
         return "\(first) ? \(second) : \(third)"
     }
 }

--- a/Sources/TranslateOperations.swift
+++ b/Sources/TranslateOperations.swift
@@ -1,8 +1,8 @@
-extension BinaryOperation {
-    public func javaScript(with indentLevel: Int) -> String {
-        let lhs = leftOperand.javaScript(with: indentLevel + 1)
-        let rhs = rightOperand.javaScript(with: indentLevel + 1)
-        switch operatorSymbol {
+extension JavaScriptTranslator {
+    func visit(_ n: BinaryOperation) throws -> String {
+        let lhs = n.leftOperand.javaScript(with: indentLevel + 1)
+        let rhs = n.rightOperand.javaScript(with: indentLevel + 1)
+        switch n.operatorSymbol {
         case "as":
             return lhs
         case "as?":
@@ -18,17 +18,15 @@ extension BinaryOperation {
         case "..<":
             return "range(\(lhs), \(rhs)" // TODO: should make specific range function
         case "&&=", "||=":
-            return "\(lhs) = \(lhs) \(operatorSymbol) \(rhs)"
+            return "\(lhs) = \(lhs) \(n.operatorSymbol) \(rhs)"
         default:
-            return "\(lhs) \(operatorSymbol) \(rhs)"
+            return "\(lhs) \(n.operatorSymbol) \(rhs)"
         }
     }
-}
-
-extension PrefixUnaryOperation {
-    public func javaScript(with indentLevel: Int) -> String {
-        let value = operand.javaScript(with: indentLevel + 1)
-        switch operatorSymbol {
+    
+    func visit(_ n: PrefixUnaryOperation) throws -> String {
+        let value = n.operand.javaScript(with: indentLevel + 1)
+        switch n.operatorSymbol {
         case "try":
             return value
         case "try!":
@@ -36,30 +34,26 @@ extension PrefixUnaryOperation {
         case "try?":
             return "tryq(\(value))"
         default:
-            return "\(operatorSymbol)\(value)"
+            return "\(n.operatorSymbol)\(value)"
         }
     }
-}
-
-extension PostfixUnaryOperation {
-    public func javaScript(with indentLevel: Int) -> String {
-        let value = operand.javaScript(with: indentLevel + 1)
-        switch operatorSymbol {
+    
+    func visit(_ n: PostfixUnaryOperation) throws -> String {
+        let value = n.operand.javaScript(with: indentLevel + 1)
+        switch n.operatorSymbol {
         case "?":
             fatalError("Never reaches here if semantic analysis is implemented.")
         case "!":
             return "x(\(value))"
         default:
-            return "\(value)\(operatorSymbol)"
+            return "\(value)\(n.operatorSymbol)"
         }
     }
-}
-
-extension TernaryOperation {
-    public func javaScript(with indentLevel: Int) -> String {
-        let first = firstOperand.javaScript(with: indentLevel + 1)
-        let second = secondOperand.javaScript(with: indentLevel + 1)
-        let third = thirdOperand.javaScript(with: indentLevel + 1)
+    
+    func visit(_ n: TernaryOperation) throws -> String {
+        let first = n.firstOperand.javaScript(with: indentLevel + 1)
+        let second = n.secondOperand.javaScript(with: indentLevel + 1)
+        let third = n.thirdOperand.javaScript(with: indentLevel + 1)
         return "\(first) ? \(second) : \(third)"
     }
 }

--- a/Sources/Transpile.swift
+++ b/Sources/Transpile.swift
@@ -2,18 +2,18 @@ import Foundation
 
 public func transpile(code: String) throws -> String {
     let statements: [Statement] = try parseTopLevel(code)
-    return transpileStatements(statements: statements, indentLevel: 0)
+    return try transpileStatements(statements: statements, indentLevel: 0)
 }
 
-public func transpileStatements(statements: [Statement], indentLevel: Int) -> String {
-    let jsStatements: [String] = statements.map { statement in
-        statement.javaScript(with: indentLevel)
+public func transpileStatements(statements: [Statement], indentLevel: Int) throws -> String {
+    let jsStatements: [String] = try statements.map { statement in
+        try statement.accept(JavaScriptTranslator(indentLevel: indentLevel))
     }
     return jsStatements.joined()
 }
 
-public func transpileBlock(statements: [Statement], indentLevel: Int) -> String {
-    return "{\n\(transpileStatements(statements: statements, indentLevel: indentLevel + 1))\(indent(of: indentLevel))}"
+public func transpileBlock(statements: [Statement], indentLevel: Int) throws -> String {
+    return "{\n\(try transpileStatements(statements: statements, indentLevel: indentLevel + 1))\(indent(of: indentLevel))}"
 }
 
 public func indent(of level: Int) -> String {

--- a/Sources/Transpile.swift
+++ b/Sources/Transpile.swift
@@ -19,3 +19,13 @@ public func transpileBlock(statements: [Statement], indentLevel: Int) -> String 
 public func indent(of level: Int) -> String {
     return "    " * level
 }
+
+internal struct JavaScriptTranslator: StatementVisitor, ExpressionVisitor, DeclarationVisitor {
+    typealias StatementResult = String
+    typealias ExpressionResult = String
+    typealias DeclarationResult = String
+    
+    let indentLevel: Int
+}
+
+internal struct UnimplementedError: Error {}

--- a/Tests/SwiftScriptTests/DeclarationsTests.swift
+++ b/Tests/SwiftScriptTests/DeclarationsTests.swift
@@ -3,17 +3,17 @@ import XCTest
 
 class DeclarationsTests: XCTestCase {
     func testConstantDeclaration() {
-        XCTAssertEqual(ConstantDeclaration(isStatic: false, name: "foo", type: TypeIdentifier(names: ["Int"]), expression: IntegerLiteral(value: 42)).javaScript(with: 0), "const foo = 42;\n")
+        XCTAssertEqual(try! ConstantDeclaration(isStatic: false, name: "foo", type: TypeIdentifier(names: ["Int"]), expression: IntegerLiteral(value: 42)).accept(JavaScriptTranslator(indentLevel: 0)), "const foo = 42;\n")
 
         // types
-        XCTAssertEqual(ConstantDeclaration(isStatic: false, name: "foo", type: OptionalType(type: TypeIdentifier(names: ["Int"])), expression: IntegerLiteral(value: 42)).javaScript(with: 0), "const foo = 42;\n")
+        XCTAssertEqual(try! ConstantDeclaration(isStatic: false, name: "foo", type: OptionalType(type: TypeIdentifier(names: ["Int"])), expression: IntegerLiteral(value: 42)).accept(JavaScriptTranslator(indentLevel: 0)), "const foo = 42;\n")
     }
     
     func testVariabletDeclaration() {
-        XCTAssertEqual(VariableDeclaration(isStatic: false, name: "foo", type: TypeIdentifier(names: ["Int"]), expression: IntegerLiteral(value: 42)).javaScript(with: 0), "let foo = 42;\n")
+        XCTAssertEqual(try! VariableDeclaration(isStatic: false, name: "foo", type: TypeIdentifier(names: ["Int"]), expression: IntegerLiteral(value: 42)).accept(JavaScriptTranslator(indentLevel: 0)), "let foo = 42;\n")
         
         // types
-        XCTAssertEqual(VariableDeclaration(isStatic: false, name: "foo", type: OptionalType(type: TypeIdentifier(names: ["Int"])), expression: IntegerLiteral(value: 42)).javaScript(with: 0), "let foo = 42;\n")
+        XCTAssertEqual(try! VariableDeclaration(isStatic: false, name: "foo", type: OptionalType(type: TypeIdentifier(names: ["Int"])), expression: IntegerLiteral(value: 42)).accept(JavaScriptTranslator(indentLevel: 0)), "let foo = 42;\n")
     }
     
     func testTypeAliasDeclaration() {
@@ -21,27 +21,27 @@ class DeclarationsTests: XCTestCase {
     }
     
     func testFunctionDeclaration() {
-        XCTAssertEqual(FunctionDeclaration(
+        XCTAssertEqual(try! FunctionDeclaration(
             isStatic: false,
             name: "foo",
             arguments: [],
             result: nil,
             hasThrows: false,
             body: []
-        ).javaScript(with: 0), "function foo() {\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "function foo() {\n}\n")
 
         // static
-        XCTAssertEqual(FunctionDeclaration(
+        XCTAssertEqual(try! FunctionDeclaration(
             isStatic: true,
             name: "foo",
             arguments: [],
             result: nil,
             hasThrows: false,
             body: []
-            ).javaScript(with: 0), "static function foo() {\n}\n")
+            ).accept(JavaScriptTranslator(indentLevel: 0)), "static function foo() {\n}\n")
 
         // arguments
-        XCTAssertEqual(FunctionDeclaration(
+        XCTAssertEqual(try! FunctionDeclaration(
             isStatic: false,
             name: "foo",
             arguments: [
@@ -61,10 +61,10 @@ class DeclarationsTests: XCTestCase {
             result: nil,
             hasThrows: false,
             body: []
-        ).javaScript(with: 0), "function foo(bar, baz) {\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "function foo(bar, baz) {\n}\n")
         
         // explicit parameter names, return type, throws
-        XCTAssertEqual(FunctionDeclaration(
+        XCTAssertEqual(try! FunctionDeclaration(
             isStatic: false,
             name: "foo",
             arguments: [
@@ -84,10 +84,10 @@ class DeclarationsTests: XCTestCase {
             result: TypeIdentifier(names: ["Void"]),
             hasThrows: true,
             body: []
-        ).javaScript(with: 0), "function foo(x, y) {\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "function foo(x, y) {\n}\n")
         
         // body
-        XCTAssertEqual(FunctionDeclaration(
+        XCTAssertEqual(try! FunctionDeclaration(
             isStatic: false,
             name: "foo",
             arguments: [
@@ -113,10 +113,10 @@ class DeclarationsTests: XCTestCase {
                     rightOperand: IdentifierExpression(identifier: "y")
                 ))
             ]
-        ).javaScript(with: 0), "function foo(x, y) {\n    return x + y;\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "function foo(x, y) {\n    return x + y;\n}\n")
         
         // indentLevel = 1
-        XCTAssertEqual(FunctionDeclaration(
+        XCTAssertEqual(try! FunctionDeclaration(
             isStatic: false,
             name: "foo",
             arguments: [
@@ -142,18 +142,18 @@ class DeclarationsTests: XCTestCase {
                     rightOperand: IdentifierExpression(identifier: "y")
                 ))
             ]
-        ).javaScript(with: 1), "    function foo(x, y) {\n        return x + y;\n    }\n")
+        ).accept(JavaScriptTranslator(indentLevel: 1)), "    function foo(x, y) {\n        return x + y;\n    }\n")
     }
     
     func testClassDeclaration() {
-        XCTAssertEqual(ClassDeclaration(
+        XCTAssertEqual(try! ClassDeclaration(
             name: "Foo",
             superTypes: [],
             members: []
-        ).javaScript(with: 0), "class Foo {\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "class Foo {\n}\n")
         
         // properties
-        XCTAssertEqual(ClassDeclaration(
+        XCTAssertEqual(try! ClassDeclaration(
             name: "Foo",
             superTypes: [],
             members: [
@@ -192,10 +192,10 @@ class DeclarationsTests: XCTestCase {
                     ]
                 ),
             ]
-        ).javaScript(with: 0), "class Foo {\n    constructor(bar) {\n        this.bar = 42;\n        this.baz = \"xyz\";\n    }\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "class Foo {\n    constructor(bar) {\n        this.bar = 42;\n        this.baz = \"xyz\";\n    }\n}\n")
         
         // methods
-        XCTAssertEqual(ClassDeclaration(
+        XCTAssertEqual(try! ClassDeclaration(
             name: "Foo",
             superTypes: [],
             members: [
@@ -208,10 +208,10 @@ class DeclarationsTests: XCTestCase {
                     body: []
                 )
             ]
-        ).javaScript(with: 0), "class Foo {\n    bar() {\n    }\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "class Foo {\n    bar() {\n    }\n}\n")
         
         // indentLevel + 1
-        XCTAssertEqual(ClassDeclaration(
+        XCTAssertEqual(try! ClassDeclaration(
             name: "Foo",
             superTypes: [],
             members: [
@@ -250,11 +250,11 @@ class DeclarationsTests: XCTestCase {
                     ]
                 ),
                 ]
-            ).javaScript(with: 1), "    class Foo {\n        constructor(bar) {\n            this.bar = 42;\n            this.baz = \"xyz\";\n        }\n    }\n")
+            ).accept(JavaScriptTranslator(indentLevel: 1)), "    class Foo {\n        constructor(bar) {\n            this.bar = 42;\n            this.baz = \"xyz\";\n        }\n    }\n")
     }
     
     func testInitializerDeclaration() {
-        XCTAssertEqual(InitializerDeclaration(
+        XCTAssertEqual(try! InitializerDeclaration(
             arguments: [],
             isFailable: false,
             hasThrows: false,
@@ -265,10 +265,10 @@ class DeclarationsTests: XCTestCase {
                     rightOperand: IntegerLiteral(value: 42)
                 ))
             ]
-        ).javaScript(with: 0), "constructor() {\n    this.foo = 42;\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "constructor() {\n    this.foo = 42;\n}\n")
         
         // arguments
-        XCTAssertEqual(InitializerDeclaration(
+        XCTAssertEqual(try! InitializerDeclaration(
             arguments: [
                 Parameter(
                     externalParameterName: nil,
@@ -296,10 +296,10 @@ class DeclarationsTests: XCTestCase {
                     )
                 ))
             ]
-        ).javaScript(with: 0), "constructor(bar, baz) {\n    this.foo = bar + baz;\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "constructor(bar, baz) {\n    this.foo = bar + baz;\n}\n")
         
         // indent
-        XCTAssertEqual(InitializerDeclaration(
+        XCTAssertEqual(try! InitializerDeclaration(
             arguments: [],
             isFailable: false,
             hasThrows: false,
@@ -310,6 +310,6 @@ class DeclarationsTests: XCTestCase {
                     rightOperand: IntegerLiteral(value: 42)
                 ))
             ]
-        ).javaScript(with: 1), "    constructor() {\n        this.foo = 42;\n    }\n")
+        ).accept(JavaScriptTranslator(indentLevel: 1)), "    constructor() {\n        this.foo = 42;\n    }\n")
     }
 }

--- a/Tests/SwiftScriptTests/ExpressionsTest.swift
+++ b/Tests/SwiftScriptTests/ExpressionsTest.swift
@@ -3,35 +3,35 @@ import XCTest
 
 class ExpressionsTests: XCTestCase {
     func testIdentifierExpression() {
-        XCTAssertEqual(IdentifierExpression(identifier: "foo").javaScript(with: 0), "foo")
+        XCTAssertEqual(try! IdentifierExpression(identifier: "foo").accept(JavaScriptTranslator(indentLevel: 0)), "foo")
     }
     
     func testSelfExpression() {
-        XCTAssertEqual(SelfExpression().javaScript(with: 0), "this")
+        XCTAssertEqual(try! SelfExpression().accept(JavaScriptTranslator(indentLevel: 0)), "this")
     }
 
     func testSuperclassExpression() {
-        XCTAssertEqual(SuperclassExpression().javaScript(with: 0), "super")
+        XCTAssertEqual(try! SuperclassExpression().accept(JavaScriptTranslator(indentLevel: 0)), "super")
     }
     
     func testClosureExpression() {
-        XCTAssertEqual(ClosureExpression(
+        XCTAssertEqual(try! ClosureExpression(
             arguments: [],
             hasThrows: false,
             result: nil,
             statements: []
-        ).javaScript(with: 0), "() => {}")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "() => {}")
         
         // single expression
-        XCTAssertEqual(ClosureExpression(
+        XCTAssertEqual(try! ClosureExpression(
             arguments: [],
             hasThrows: false,
             result: nil,
             statements: [ExpressionStatement(IntegerLiteral(value: 42))]
-        ).javaScript(with: 0), "() => 42")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "() => 42")
         
         // multiple statments
-        XCTAssertEqual(ClosureExpression(
+        XCTAssertEqual(try! ClosureExpression(
             arguments: [],
             hasThrows: false,
             result: nil,
@@ -39,10 +39,10 @@ class ExpressionsTests: XCTestCase {
                 DeclarationStatement(ConstantDeclaration(isStatic: false, name: "foo", type: TypeIdentifier(names: ["Int"]), expression: IntegerLiteral(value: 42))),
                 ReturnStatement(expression: IdentifierExpression(identifier: "foo"))
             ]
-        ).javaScript(with: 0), "() => {\n    const foo = 42;\n    return foo;\n}")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "() => {\n    const foo = 42;\n    return foo;\n}")
         
         // indentLevel = 1
-        XCTAssertEqual(ClosureExpression(
+        XCTAssertEqual(try! ClosureExpression(
             arguments: [],
             hasThrows: false,
             result: nil,
@@ -50,18 +50,18 @@ class ExpressionsTests: XCTestCase {
                 DeclarationStatement(ConstantDeclaration(isStatic: false, name: "foo", type: TypeIdentifier(names: ["Int"]), expression: IntegerLiteral(value: 42))),
                 ReturnStatement(expression: IdentifierExpression(identifier: "foo"))
             ]
-        ).javaScript(with: 1), "() => {\n        const foo = 42;\n        return foo;\n    }")
+        ).accept(JavaScriptTranslator(indentLevel: 1)), "() => {\n        const foo = 42;\n        return foo;\n    }")
         
         // throws
-        XCTAssertEqual(ClosureExpression(
+        XCTAssertEqual(try! ClosureExpression(
             arguments: [],
             hasThrows: true,
             result: nil,
             statements: [ExpressionStatement(IntegerLiteral(value: 42))]
-        ).javaScript(with: 0), "() => 42")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "() => 42")
         
         // arguments
-        XCTAssertEqual(ClosureExpression(
+        XCTAssertEqual(try! ClosureExpression(
             arguments: [("x", nil), ("y", nil)],
             hasThrows: false,
             result: nil,
@@ -70,10 +70,10 @@ class ExpressionsTests: XCTestCase {
                 operatorSymbol: "+",
                 rightOperand: IdentifierExpression(identifier: "y")
             ))]
-        ).javaScript(with: 0), "(x, y) => x + y")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "(x, y) => x + y")
         
         // arguments with types
-        XCTAssertEqual(ClosureExpression(
+        XCTAssertEqual(try! ClosureExpression(
             arguments: [("x", TypeIdentifier(names: ["Int"])), ("y", TypeIdentifier(names: ["Int"]))],
             hasThrows: false,
             result: TypeIdentifier(names: ["Int"]),
@@ -82,93 +82,93 @@ class ExpressionsTests: XCTestCase {
                 operatorSymbol: "+",
                 rightOperand: IdentifierExpression(identifier: "y")
                 ))]
-            ).javaScript(with: 0), "(x, y) => x + y")
+            ).accept(JavaScriptTranslator(indentLevel: 0)), "(x, y) => x + y")
     }
     
     func testParenthesizedExpression() {
-        XCTAssertEqual(ParenthesizedExpression(expression: IdentifierExpression(identifier: "foo")).javaScript(with: 0), "(foo)")
+        XCTAssertEqual(try! ParenthesizedExpression(expression: IdentifierExpression(identifier: "foo")).accept(JavaScriptTranslator(indentLevel: 0)), "(foo)")
     }
     
     func testTupleExpression() {
-        XCTAssertEqual(TupleExpression(elements: [
+        XCTAssertEqual(try! TupleExpression(elements: [
             (nil, IntegerLiteral(value: 2)),
             (nil, IntegerLiteral(value: 3)),
             (nil, IntegerLiteral(value: 5)),
-        ]).javaScript(with: 0), "[2, 3, 5]")
+        ]).accept(JavaScriptTranslator(indentLevel: 0)), "[2, 3, 5]")
         
         // labels
-        XCTAssertEqual(TupleExpression(elements: [
+        XCTAssertEqual(try! TupleExpression(elements: [
             ("foo", IntegerLiteral(value: 2)),
             ("bar", IntegerLiteral(value: 3)),
             ("baz", IntegerLiteral(value: 5)),
-        ]).javaScript(with: 0), "[2, 3, 5]")
+        ]).accept(JavaScriptTranslator(indentLevel: 0)), "[2, 3, 5]")
     }
     
     func testWildcardExpression() {
-        XCTAssertEqual(WildcardExpression().javaScript(with: 0), "_")
+        XCTAssertEqual(try! WildcardExpression().accept(JavaScriptTranslator(indentLevel: 0)), "_")
     }
     
     func testFunctionCallExpression() {
-        XCTAssertEqual(FunctionCallExpression(
+        XCTAssertEqual(try! FunctionCallExpression(
             expression: IdentifierExpression(identifier: "foo"),
             arguments: [],
             trailingClosure: nil
-        ).javaScript(with: 0), "foo()")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "foo()")
         
         // new
-        XCTAssertEqual(FunctionCallExpression(
+        XCTAssertEqual(try! FunctionCallExpression(
             expression: IdentifierExpression(identifier: "Foo"),
             arguments: [],
             trailingClosure: nil
-        ).javaScript(with: 0), "new Foo()")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "new Foo()")
         
         // arguments
-        XCTAssertEqual(FunctionCallExpression(
+        XCTAssertEqual(try! FunctionCallExpression(
             expression: IdentifierExpression(identifier: "foo"),
             arguments: [
                 (nil, IntegerLiteral(value: 42)),
                 (nil, StringLiteral(value: "xyz")),
             ],
             trailingClosure: nil
-        ).javaScript(with: 0), "foo(42, \"xyz\")")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "foo(42, \"xyz\")")
         
         // labels
-        XCTAssertEqual(FunctionCallExpression(
+        XCTAssertEqual(try! FunctionCallExpression(
             expression: IdentifierExpression(identifier: "foo"),
             arguments: [
                 ("bar", IntegerLiteral(value: 42)),
                 ("baz", StringLiteral(value: "xyz")),
             ],
             trailingClosure: nil
-        ).javaScript(with: 0), "foo(42, \"xyz\")")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "foo(42, \"xyz\")")
 
         // trailing closures
-        XCTAssertEqual(FunctionCallExpression(
+        XCTAssertEqual(try! FunctionCallExpression(
             expression: IdentifierExpression(identifier: "foo"),
             arguments: [
                 (nil, IntegerLiteral(value: 42)),
                 (nil, StringLiteral(value: "xyz")),
                 ],
             trailingClosure: ClosureExpression(arguments: [], hasThrows: false, result: nil, statements: [])
-        ).javaScript(with: 0), "foo(42, \"xyz\", () => {})")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "foo(42, \"xyz\", () => {})")
         
         // calls just after a closure expression
-        XCTAssertEqual(FunctionCallExpression(
+        XCTAssertEqual(try! FunctionCallExpression(
             expression: ClosureExpression(arguments: [], hasThrows: false, result: nil, statements: [
                 ExpressionStatement(IntegerLiteral(value: 42)),
             ]),
             arguments: [],
             trailingClosure: nil
-        ).javaScript(with: 0), "(() => 42)()")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "(() => 42)()")
     }
     
     func testInitializerExpression() {
         // `super.init`
-        XCTAssertEqual(ExplicitMemberExpression(expression: SuperclassExpression(), member: "init").javaScript(with: 0), "super")
+        XCTAssertEqual(try! ExplicitMemberExpression(expression: SuperclassExpression(), member: "init").accept(JavaScriptTranslator(indentLevel: 0)), "super")
     }
     
     func testExplicitMemberExpression() {
-        XCTAssertEqual(ExplicitMemberExpression(expression: IdentifierExpression(identifier: "foo"), member: "bar").javaScript(with: 0), "foo.bar")
+        XCTAssertEqual(try! ExplicitMemberExpression(expression: IdentifierExpression(identifier: "foo"), member: "bar").accept(JavaScriptTranslator(indentLevel: 0)), "foo.bar")
     }
     
     func testDynamicTypeExpression() {
@@ -176,44 +176,44 @@ class ExpressionsTests: XCTestCase {
     }
     
     func testSubscriptExpression() {
-        XCTAssertEqual(SubscriptExpression(
+        XCTAssertEqual(try! SubscriptExpression(
             expression: IdentifierExpression(identifier: "foo"),
             arguments: [IntegerLiteral(value: 42)]
-        ).javaScript(with: 0), "foo[42]")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "foo[42]")
         
         // calls just after a closure expression
-        XCTAssertEqual(SubscriptExpression(
+        XCTAssertEqual(try! SubscriptExpression(
             expression: ClosureExpression(arguments: [], hasThrows: false, result: nil, statements: [
                 ExpressionStatement(IntegerLiteral(value: 42)),
                 ]),
             arguments: [IntegerLiteral(value: 0)]
-        ).javaScript(with: 0), "(() => 42)[0]")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "(() => 42)[0]")
     }
     
     func testOptionalChainingExpression() {
-        XCTAssertEqual(ExplicitMemberExpression(
+        XCTAssertEqual(try! ExplicitMemberExpression(
             expression: PostfixUnaryOperation(
                 operand: IdentifierExpression(identifier: "foo"),
                 operatorSymbol: "?"
             ),
             member: "bar"
-        ).javaScript(with: 0), "q(foo, (x) => x.bar)")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "q(foo, (x) => x.bar)")
         
-        XCTAssertEqual(SubscriptExpression(
+        XCTAssertEqual(try! SubscriptExpression(
             expression: PostfixUnaryOperation(
                 operand: IdentifierExpression(identifier: "foo"),
                 operatorSymbol: "?"
             ),
             arguments: [IntegerLiteral(value: 0)]
-        ).javaScript(with: 0), "q(foo, (x) => x[0])")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "q(foo, (x) => x[0])")
         
-        XCTAssertEqual(FunctionCallExpression(
+        XCTAssertEqual(try! FunctionCallExpression(
             expression: PostfixUnaryOperation(
                 operand: IdentifierExpression(identifier: "foo"),
                 operatorSymbol: "?"
             ),
             arguments: [],
             trailingClosure: nil
-        ).javaScript(with: 0), "q(foo, (x) => x())")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "q(foo, (x) => x())")
     }
 }

--- a/Tests/SwiftScriptTests/LiteralsTests.swift
+++ b/Tests/SwiftScriptTests/LiteralsTests.swift
@@ -3,45 +3,45 @@ import XCTest
 
 class LiteralsTests: XCTestCase {
     func testArrayLiteral() {
-        XCTAssertEqual(ArrayLiteral(value: [
+        XCTAssertEqual(try! ArrayLiteral(value: [
             IntegerLiteral(value: 2),
             IntegerLiteral(value: 3),
             IntegerLiteral(value: 5),
-        ]).javaScript(with: 0), "[2, 3, 5]")
+        ]).accept(JavaScriptTranslator(indentLevel: 0)), "[2, 3, 5]")
     }
     
     func testDictionaryLiteral() {
-        XCTAssertEqual(SwiftScript.DictionaryLiteral(value: [
+        XCTAssertEqual(try! SwiftScript.DictionaryLiteral(value: [
             (StringLiteral(value: "foo"), IntegerLiteral(value: 2)),
             (StringLiteral(value: "bar"), IntegerLiteral(value: 3)),
             (StringLiteral(value: "baz"), IntegerLiteral(value: 5)),
-        ]).javaScript(with: 0), "{\n    \"foo\": 2,\n    \"bar\": 3,\n    \"baz\": 5\n}")
+        ]).accept(JavaScriptTranslator(indentLevel: 0)), "{\n    \"foo\": 2,\n    \"bar\": 3,\n    \"baz\": 5\n}")
         
-        XCTAssertEqual(SwiftScript.DictionaryLiteral(value: [
+        XCTAssertEqual(try! SwiftScript.DictionaryLiteral(value: [
             (StringLiteral(value: "foo"), IntegerLiteral(value: 2)),
             (StringLiteral(value: "bar"), IntegerLiteral(value: 3)),
             (StringLiteral(value: "baz"), IntegerLiteral(value: 5)),
-            ]).javaScript(with: 1), "{\n        \"foo\": 2,\n        \"bar\": 3,\n        \"baz\": 5\n    }")
+            ]).accept(JavaScriptTranslator(indentLevel: 1)), "{\n        \"foo\": 2,\n        \"bar\": 3,\n        \"baz\": 5\n    }")
     }
     
     func testIntegerLiteral() {
-        XCTAssertEqual(IntegerLiteral(value: 42).javaScript(with: 0), "42")
+        XCTAssertEqual(try! IntegerLiteral(value: 42).accept(JavaScriptTranslator(indentLevel: 0)), "42")
     }
 
     func testFloatingPointLiteral() {
-        XCTAssertEqual(FloatingPointLiteral(value: 12.5).javaScript(with: 0), "12.5")
+        XCTAssertEqual(try! FloatingPointLiteral(value: 12.5).accept(JavaScriptTranslator(indentLevel: 0)), "12.5")
     }
     
     func testStringLiteral() {
-        XCTAssertEqual(StringLiteral(value: "xyz").javaScript(with: 0), "\"xyz\"")
+        XCTAssertEqual(try! StringLiteral(value: "xyz").accept(JavaScriptTranslator(indentLevel: 0)), "\"xyz\"")
     }
     
     func testBooleanLiteral() {
-        XCTAssertEqual(BooleanLiteral(value: true).javaScript(with: 0), "true")
-        XCTAssertEqual(BooleanLiteral(value: false).javaScript(with: 0), "false")
+        XCTAssertEqual(try! BooleanLiteral(value: true).accept(JavaScriptTranslator(indentLevel: 0)), "true")
+        XCTAssertEqual(try! BooleanLiteral(value: false).accept(JavaScriptTranslator(indentLevel: 0)), "false")
     }
     
     func testNilLiteral() {
-        XCTAssertEqual(NilLiteral().javaScript(with: 0), "null")
+        XCTAssertEqual(try! NilLiteral().accept(JavaScriptTranslator(indentLevel: 0)), "null")
     }
 }

--- a/Tests/SwiftScriptTests/OperationsTests.swift
+++ b/Tests/SwiftScriptTests/OperationsTests.swift
@@ -3,42 +3,42 @@ import XCTest
 
 class OperationsTests: XCTestCase {
     func testBinaryOperation() {
-        XCTAssertEqual(BinaryOperation(
+        XCTAssertEqual(try! BinaryOperation(
             leftOperand: IntegerLiteral(value: 2),
             operatorSymbol: "+",
             rightOperand: IntegerLiteral(value: 3)
-        ).javaScript(with: 0), "2 + 3")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "2 + 3")
     }
 
     func testPrefixUnaryOperation() {
-        XCTAssertEqual(PrefixUnaryOperation(
+        XCTAssertEqual(try! PrefixUnaryOperation(
             operatorSymbol: "!",
             operand: BooleanLiteral(value: true)
-            ).javaScript(with: 0), "!true")
+            ).accept(JavaScriptTranslator(indentLevel: 0)), "!true")
         
-        XCTAssertEqual(PrefixUnaryOperation(
+        XCTAssertEqual(try! PrefixUnaryOperation(
             operatorSymbol: "try",
             operand: FunctionCallExpression(expression: IdentifierExpression(identifier: "foo"), arguments: [], trailingClosure: nil)
-        ).javaScript(with: 0), "foo()")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "foo()")
         
-        XCTAssertEqual(PrefixUnaryOperation(
+        XCTAssertEqual(try! PrefixUnaryOperation(
             operatorSymbol: "try!",
             operand: FunctionCallExpression(expression: IdentifierExpression(identifier: "foo"), arguments: [], trailingClosure: nil)
-            ).javaScript(with: 0), "tryx(foo())")
+            ).accept(JavaScriptTranslator(indentLevel: 0)), "tryx(foo())")
     }
     
     func testPostfixUnaryOperation() {
-        XCTAssertEqual(PostfixUnaryOperation(
+        XCTAssertEqual(try! PostfixUnaryOperation(
             operand: IdentifierExpression(identifier: "foo"),
             operatorSymbol: "!"
-        ).javaScript(with: 0), "x(foo)")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "x(foo)")
     }
     
     func testTernaryOperation() {
-        XCTAssertEqual(TernaryOperation(
+        XCTAssertEqual(try! TernaryOperation(
             firstOperand: IdentifierExpression(identifier: "foo"),
             secondOperand: IntegerLiteral(value: 2),
             thirdOperand: IntegerLiteral(value: 3)
-        ).javaScript(with: 0), "foo ? 2 : 3")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "foo ? 2 : 3")
     }
 }

--- a/Tests/SwiftScriptTests/StatementsTests.swift
+++ b/Tests/SwiftScriptTests/StatementsTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 class StatementsTests: XCTestCase {
     func testForInStatement() {
-        XCTAssertEqual(ForInStatement(
+        XCTAssertEqual(try! ForInStatement(
             item: "i",
             collection: BinaryOperation(
                 leftOperand: IntegerLiteral(value: 0),
@@ -17,10 +17,10 @@ class StatementsTests: XCTestCase {
                     trailingClosure: nil
                 ))
             ]
-        ).javaScript(with: 0), "for (i of range(0, 10) {\n    console.log(i);\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "for (i of range(0, 10) {\n    console.log(i);\n}\n")
         
         // indent
-        XCTAssertEqual(ForInStatement(
+        XCTAssertEqual(try! ForInStatement(
             item: "i",
             collection: BinaryOperation(
                 leftOperand: IntegerLiteral(value: 0),
@@ -34,11 +34,11 @@ class StatementsTests: XCTestCase {
                     trailingClosure: nil
                 ))
             ]
-        ).javaScript(with: 1), "    for (i of range(0, 10) {\n        console.log(i);\n    }\n")
+        ).accept(JavaScriptTranslator(indentLevel: 1)), "    for (i of range(0, 10) {\n        console.log(i);\n    }\n")
     }
     
     func testWhileStatement() {
-        XCTAssertEqual(WhileStatement(
+        XCTAssertEqual(try! WhileStatement(
             condition: BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "<", rightOperand: IntegerLiteral(value: 42)),
             statements: [
                 ExpressionStatement(FunctionCallExpression(
@@ -47,10 +47,10 @@ class StatementsTests: XCTestCase {
                     trailingClosure: nil
                 ))
             ]
-        ).javaScript(with: 0), "while (foo < 42) {\n    console.log(\"Hello\");\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "while (foo < 42) {\n    console.log(\"Hello\");\n}\n")
         
         // indent
-        XCTAssertEqual(WhileStatement(
+        XCTAssertEqual(try! WhileStatement(
             condition: BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "<", rightOperand: IntegerLiteral(value: 42)),
             statements: [
                 ExpressionStatement(FunctionCallExpression(
@@ -59,11 +59,11 @@ class StatementsTests: XCTestCase {
                     trailingClosure: nil
                 ))
             ]
-        ).javaScript(with: 1), "    while (foo < 42) {\n        console.log(\"Hello\");\n    }\n")
+        ).accept(JavaScriptTranslator(indentLevel: 1)), "    while (foo < 42) {\n        console.log(\"Hello\");\n    }\n")
     }
     
     func testRepeatWhileStatement() {
-        XCTAssertEqual(RepeatWhileStatement(
+        XCTAssertEqual(try! RepeatWhileStatement(
             statements: [
                 ExpressionStatement(FunctionCallExpression(
                     expression: IdentifierExpression(identifier: "print"),
@@ -72,10 +72,10 @@ class StatementsTests: XCTestCase {
                 ))
             ],
             condition: BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "<", rightOperand: IntegerLiteral(value: 42))
-        ).javaScript(with: 0), "repeat {\n    console.log(\"Hello\");\n} while (foo < 42)\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "repeat {\n    console.log(\"Hello\");\n} while (foo < 42)\n")
         
         // indent
-        XCTAssertEqual(RepeatWhileStatement(
+        XCTAssertEqual(try! RepeatWhileStatement(
             statements: [
                 ExpressionStatement(FunctionCallExpression(
                     expression: IdentifierExpression(identifier: "print"),
@@ -84,11 +84,11 @@ class StatementsTests: XCTestCase {
                 ))
             ],
             condition: BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "<", rightOperand: IntegerLiteral(value: 42))
-        ).javaScript(with: 1), "    repeat {\n        console.log(\"Hello\");\n    } while (foo < 42)\n")
+        ).accept(JavaScriptTranslator(indentLevel: 1)), "    repeat {\n        console.log(\"Hello\");\n    } while (foo < 42)\n")
     }
     
     func testIfStatement() {
-        XCTAssertEqual(IfStatement(
+        XCTAssertEqual(try! IfStatement(
             condition: .boolean(BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "<", rightOperand: IntegerLiteral(value: 42))),
             statements: [
                 ExpressionStatement(FunctionCallExpression(
@@ -98,10 +98,10 @@ class StatementsTests: XCTestCase {
                 ))
             ],
             elseClause: nil
-        ).javaScript(with: 0), "if (foo < 42) {\n    console.log(\"Hello\");\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "if (foo < 42) {\n    console.log(\"Hello\");\n}\n")
         
         // if-else
-        XCTAssertEqual(IfStatement(
+        XCTAssertEqual(try! IfStatement(
             condition: .boolean(BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "<", rightOperand: IntegerLiteral(value: 42))),
             statements: [
                 ExpressionStatement(FunctionCallExpression(
@@ -117,10 +117,10 @@ class StatementsTests: XCTestCase {
                     trailingClosure: nil
                 ))
             ])
-        ).javaScript(with: 0), "if (foo < 42) {\n    console.log(\"Hello\");\n} else {\n    console.log(\"Bye\");\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "if (foo < 42) {\n    console.log(\"Hello\");\n} else {\n    console.log(\"Bye\");\n}\n")
         
         // if-else-if
-        XCTAssertEqual(IfStatement(
+        XCTAssertEqual(try! IfStatement(
             condition: .boolean(BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "<", rightOperand: IntegerLiteral(value: 42))),
             statements: [
                 ExpressionStatement(FunctionCallExpression(
@@ -140,10 +140,10 @@ class StatementsTests: XCTestCase {
                 ],
                 elseClause: nil
             ))
-        ).javaScript(with: 0), "if (foo < 42) {\n    console.log(\"Hello\");\n} else if (foo == 0) {\n    console.log(\"Bye\");\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "if (foo < 42) {\n    console.log(\"Hello\");\n} else if (foo == 0) {\n    console.log(\"Bye\");\n}\n")
         
         // indent
-        XCTAssertEqual(IfStatement(
+        XCTAssertEqual(try! IfStatement(
             condition: .boolean(BinaryOperation(leftOperand: IdentifierExpression(identifier: "foo"), operatorSymbol: "<", rightOperand: IntegerLiteral(value: 42))),
             statements: [
                 ExpressionStatement(FunctionCallExpression(
@@ -163,29 +163,29 @@ class StatementsTests: XCTestCase {
                     ],
                 elseClause: nil
             ))
-        ).javaScript(with: 1), "    if (foo < 42) {\n        console.log(\"Hello\");\n    } else if (foo == 0) {\n        console.log(\"Bye\");\n    }\n")
+        ).accept(JavaScriptTranslator(indentLevel: 1)), "    if (foo < 42) {\n        console.log(\"Hello\");\n    } else if (foo == 0) {\n        console.log(\"Bye\");\n    }\n")
         
         // optional binding
-        XCTAssertEqual(IfStatement(
+        XCTAssertEqual(try! IfStatement(
             condition: .optionalBinding(false, "foo", IdentifierExpression(identifier: "bar")),
             statements: [
                 ExpressionStatement(FunctionCallExpression(expression: IdentifierExpression(identifier: "print"), arguments: [(nil, IdentifierExpression(identifier: "foo"))], trailingClosure: nil)),
             ],
             elseClause: nil
-        ).javaScript(with: 0), "{\n    let foo;\n    if ((foo = bar) != null) {\n        console.log(foo);\n    }\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "{\n    let foo;\n    if ((foo = bar) != null) {\n        console.log(foo);\n    }\n}\n")
         
         // optional binding (let foo = foo)
-        XCTAssertEqual(IfStatement(
+        XCTAssertEqual(try! IfStatement(
             condition: .optionalBinding(false, "foo", IdentifierExpression(identifier: "foo")),
             statements: [
                 ExpressionStatement(FunctionCallExpression(expression: IdentifierExpression(identifier: "print"), arguments: [(nil, IdentifierExpression(identifier: "foo"))], trailingClosure: nil)),
                 ],
             elseClause: nil
-        ).javaScript(with: 0), "if (foo != null) {\n    console.log(foo);\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "if (foo != null) {\n    console.log(foo);\n}\n")
     }
     
     func testGuardStatement() {
-        XCTAssertEqual(GuardStatement(
+        XCTAssertEqual(try! GuardStatement(
             condition: .boolean(BinaryOperation(
                 leftOperand: IdentifierExpression(identifier: "foo"),
                 operatorSymbol: "==",
@@ -193,10 +193,10 @@ class StatementsTests: XCTestCase {
             statements: [
                 ReturnStatement(expression: IntegerLiteral(value: 0)),
             ]
-        ).javaScript(with: 0), "if (!(foo == 42)) {\n    return 0;\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "if (!(foo == 42)) {\n    return 0;\n}\n")
         
         // indent
-        XCTAssertEqual(GuardStatement(
+        XCTAssertEqual(try! GuardStatement(
             condition: .boolean(BinaryOperation(
                 leftOperand: IdentifierExpression(identifier: "foo"),
                 operatorSymbol: "==",
@@ -204,86 +204,86 @@ class StatementsTests: XCTestCase {
             statements: [
                 ReturnStatement(expression: IntegerLiteral(value: 0)),
                 ]
-        ).javaScript(with: 1), "    if (!(foo == 42)) {\n        return 0;\n    }\n")
+        ).accept(JavaScriptTranslator(indentLevel: 1)), "    if (!(foo == 42)) {\n        return 0;\n    }\n")
         
         // optional binding
-        XCTAssertEqual(GuardStatement(
+        XCTAssertEqual(try! GuardStatement(
             condition: .optionalBinding(false, "foo", IdentifierExpression(identifier: "bar")),
             statements: [
                 ReturnStatement(expression: nil),
             ]
-        ).javaScript(with: 0), "let foo;\nif ((foo = bar) == null) {\n    return;\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "let foo;\nif ((foo = bar) == null) {\n    return;\n}\n")
         
         // optional binding (let foo = foo)
-        XCTAssertEqual(GuardStatement(
+        XCTAssertEqual(try! GuardStatement(
             condition: .optionalBinding(false, "foo", IdentifierExpression(identifier: "foo")),
             statements: [
                 ReturnStatement(expression: nil),
                 ]
-        ).javaScript(with: 0), "if (foo == null) {\n    return;\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "if (foo == null) {\n    return;\n}\n")
     }
     
     func testLabeledStatement() {
-        XCTAssertEqual(LabeledStatement(labelName: "foo", statement: WhileStatement(
+        XCTAssertEqual(try! LabeledStatement(labelName: "foo", statement: WhileStatement(
             condition: BooleanLiteral(value: true),
             statements: [
                 BreakStatement(labelName: "foo"),
             ]
-        )).javaScript(with: 0), "foo: while (true) {\n    break foo;\n}\n")
+        )).accept(JavaScriptTranslator(indentLevel: 0)), "foo: while (true) {\n    break foo;\n}\n")
         
         // indent
-        XCTAssertEqual(LabeledStatement(labelName: "foo", statement: WhileStatement(
+        XCTAssertEqual(try! LabeledStatement(labelName: "foo", statement: WhileStatement(
             condition: BooleanLiteral(value: true),
             statements: [
                 BreakStatement(labelName: "foo"),
                 ]
-        )).javaScript(with: 1), "    foo: while (true) {\n        break foo;\n    }\n")
+        )).accept(JavaScriptTranslator(indentLevel: 1)), "    foo: while (true) {\n        break foo;\n    }\n")
     }
     
     func testBreakStatement() {
-        XCTAssertEqual(BreakStatement().javaScript(with: 0), "break;\n")
-        XCTAssertEqual(BreakStatement(labelName: "foo").javaScript(with: 0), "break foo;\n")
+        XCTAssertEqual(try! BreakStatement().accept(JavaScriptTranslator(indentLevel: 0)), "break;\n")
+        XCTAssertEqual(try! BreakStatement(labelName: "foo").accept(JavaScriptTranslator(indentLevel: 0)), "break foo;\n")
 
         // indent
-        XCTAssertEqual(BreakStatement().javaScript(with: 1), "    break;\n")
+        XCTAssertEqual(try! BreakStatement().accept(JavaScriptTranslator(indentLevel: 1)), "    break;\n")
     }
     
     func testContinueStatement() {
-        XCTAssertEqual(ContinueStatement().javaScript(with: 0), "continue;\n")
-        XCTAssertEqual(ContinueStatement(labelName: "foo").javaScript(with: 0), "continue foo;\n")
+        XCTAssertEqual(try! ContinueStatement().accept(JavaScriptTranslator(indentLevel: 0)), "continue;\n")
+        XCTAssertEqual(try! ContinueStatement(labelName: "foo").accept(JavaScriptTranslator(indentLevel: 0)), "continue foo;\n")
         
         // indent
-        XCTAssertEqual(ContinueStatement().javaScript(with: 1), "    continue;\n")
+        XCTAssertEqual(try! ContinueStatement().accept(JavaScriptTranslator(indentLevel: 1)), "    continue;\n")
     }
     
     func testFallthroughStatement() {
-        XCTAssertEqual(FallthroughStatement().javaScript(with: 0), "")
+        XCTAssertEqual(try! FallthroughStatement().accept(JavaScriptTranslator(indentLevel: 0)), "")
         
         // indent
-        XCTAssertEqual(FallthroughStatement().javaScript(with: 1), "") // no indent because no `fallthrough` in JS
+        XCTAssertEqual(try! FallthroughStatement().accept(JavaScriptTranslator(indentLevel: 1)), "") // no indent because no `fallthrough` in JS
     }
     
     func testReturnStatement() {
-        XCTAssertEqual(ReturnStatement(expression: nil).javaScript(with: 0), "return;\n")
-        XCTAssertEqual(ReturnStatement(expression: IntegerLiteral(value: 42)).javaScript(with: 0), "return 42;\n")
+        XCTAssertEqual(try! ReturnStatement(expression: nil).accept(JavaScriptTranslator(indentLevel: 0)), "return;\n")
+        XCTAssertEqual(try! ReturnStatement(expression: IntegerLiteral(value: 42)).accept(JavaScriptTranslator(indentLevel: 0)), "return 42;\n")
         
         // indent
-        XCTAssertEqual(ReturnStatement(expression: nil).javaScript(with: 1), "    return;\n")
+        XCTAssertEqual(try! ReturnStatement(expression: nil).accept(JavaScriptTranslator(indentLevel: 1)), "    return;\n")
     }
     
     func testThrowStatement() {
-        XCTAssertEqual(ThrowStatement(expression: FunctionCallExpression(
+        XCTAssertEqual(try! ThrowStatement(expression: FunctionCallExpression(
             expression: IdentifierExpression(identifier: "FooError"),
             arguments: [],
             trailingClosure: nil)
-        ).javaScript(with: 0), "throw new FooError();\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "throw new FooError();\n")
         
         // indent
-        XCTAssertEqual(ThrowStatement(expression: FunctionCallExpression(
+        XCTAssertEqual(try! ThrowStatement(expression: FunctionCallExpression(
             expression: IdentifierExpression(identifier: "FooError"),
             arguments: [],
             trailingClosure: nil)
-        ).javaScript(with: 1), "    throw new FooError();\n")
+        ).accept(JavaScriptTranslator(indentLevel: 1)), "    throw new FooError();\n")
     }
     
     func testDeferStatement() {
@@ -291,7 +291,7 @@ class StatementsTests: XCTestCase {
     }
     
     func testDoStatement() {
-        XCTAssertEqual(DoStatement(
+        XCTAssertEqual(try! DoStatement(
             statements: [
                 ExpressionStatement(FunctionCallExpression(
                     expression: IdentifierExpression(identifier: "print"),
@@ -300,11 +300,11 @@ class StatementsTests: XCTestCase {
                 ))
             ],
             catchClauses: []
-        ).javaScript(with: 0), "{\n    console.log(\"Hello\");\n}\n")
+        ).accept(JavaScriptTranslator(indentLevel: 0)), "{\n    console.log(\"Hello\");\n}\n")
         // TODO: catch
         
         // indent
-        XCTAssertEqual(DoStatement(
+        XCTAssertEqual(try! DoStatement(
             statements: [
                 ExpressionStatement(FunctionCallExpression(
                     expression: IdentifierExpression(identifier: "print"),
@@ -313,6 +313,6 @@ class StatementsTests: XCTestCase {
                 ))
             ],
             catchClauses: []
-        ).javaScript(with: 1), "    {\n        console.log(\"Hello\");\n    }\n")
+        ).accept(JavaScriptTranslator(indentLevel: 1)), "    {\n        console.log(\"Hello\");\n    }\n")
     }
 }


### PR DESCRIPTION
Replace the `javaScript` methods of `Node`s with a visitor `JavaScriptTranslator`.